### PR TITLE
Fix MagicOnion ServiceDescriptor for StateMachineService

### DIFF
--- a/src/REstate.Remote/Properties/AssemblyInfo.cs
+++ b/src/REstate.Remote/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+[assembly: InternalsVisibleTo("REstate.Remote.Tests")]
+
+// This is Moq
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/REstate.Remote/Services/StateMachineService.cs
+++ b/src/REstate.Remote/Services/StateMachineService.cs
@@ -139,7 +139,7 @@ namespace REstate.Remote.Services
                 GetCallCancellationToken());
         }
 
-        public virtual async Task<SendResponse> SendAsync<TState, TInput>(
+        internal virtual async Task<SendResponse> SendAsync<TState, TInput>(
             string machineId,
             TInput input,
             Guid? commitTag,
@@ -226,7 +226,7 @@ namespace REstate.Remote.Services
                     GetCallCancellationToken());
         }
 
-        public virtual async Task<SendResponse> SendWithPayloadAsync<TState, TInput, TPayload>(string machineId, TInput input, TPayload payload, Guid? commitTag, CancellationToken cancellationToken = default)
+        internal virtual async Task<SendResponse> SendWithPayloadAsync<TState, TInput, TPayload>(string machineId, TInput input, TPayload payload, Guid? commitTag, CancellationToken cancellationToken = default)
         {
             var engine = REstateHost.Agent.AsLocal()
                 .GetStateEngine<TState, TInput>();
@@ -300,7 +300,7 @@ namespace REstate.Remote.Services
             return await storeSchematicAsync(schematic, GetCallCancellationToken());
         }
 
-        public virtual async Task<StoreSchematicResponse> StoreSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, CancellationToken cancellationToken = default)
+        internal virtual async Task<StoreSchematicResponse> StoreSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, CancellationToken cancellationToken = default)
         {
             var engine = REstateHost.Agent.AsLocal()
                 .GetStateEngine<TState, TInput>();
@@ -351,7 +351,7 @@ namespace REstate.Remote.Services
             return await getMachineSchematicAsync(request.MachineId, GetCallCancellationToken());
         }
 
-        public virtual async Task<GetMachineSchematicResponse> GetMachineSchematicAsync<TState, TInput>(string machineId, CancellationToken cancellationToken = default)
+        internal virtual async Task<GetMachineSchematicResponse> GetMachineSchematicAsync<TState, TInput>(string machineId, CancellationToken cancellationToken = default)
         {
             var engine = REstateHost.Agent
                 .AsLocal()
@@ -406,7 +406,7 @@ namespace REstate.Remote.Services
             return await getMachineMetadataAsync(request.MachineId, GetCallCancellationToken());
         }
 
-        public virtual async Task<GetMachineMetadataResponse> GetMachineMetadataAsync<TState, TInput>(string machineId, CancellationToken cancellationToken = default)
+        internal virtual async Task<GetMachineMetadataResponse> GetMachineMetadataAsync<TState, TInput>(string machineId, CancellationToken cancellationToken = default)
         {
             var engine = REstateHost.Agent
                 .AsLocal()
@@ -466,7 +466,7 @@ namespace REstate.Remote.Services
                 GetCallCancellationToken());
         }
 
-        public virtual async Task<CreateMachineResponse> CreateMachineFromStoreAsync<TState, TInput>(string schematicName,
+        internal virtual async Task<CreateMachineResponse> CreateMachineFromStoreAsync<TState, TInput>(string schematicName,
             IDictionary<string, string> metadata, CancellationToken cancellationToken = default)
         {
             var engine = REstateHost.Agent
@@ -531,7 +531,7 @@ namespace REstate.Remote.Services
                 GetCallCancellationToken());
         }
 
-        public virtual async Task<CreateMachineResponse> CreateMachineFromSchematicAsync<TState, TInput>(
+        internal virtual async Task<CreateMachineResponse> CreateMachineFromSchematicAsync<TState, TInput>(
             Schematic<TState, TInput> schematic,
             IDictionary<string, string> metadata,
             CancellationToken cancellationToken = default)
@@ -590,7 +590,7 @@ namespace REstate.Remote.Services
             return Nil.Default;
         }
 
-        public virtual async Task BulkCreateMachineFromStoreAsync<TState, TInput>(
+        internal virtual async Task BulkCreateMachineFromStoreAsync<TState, TInput>(
             string schematicName,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default)
@@ -650,7 +650,7 @@ namespace REstate.Remote.Services
             return Nil.Default;
         }
 
-        public virtual async Task BulkCreateMachineFromSchematicAsync<TState, TInput>(
+        internal virtual async Task BulkCreateMachineFromSchematicAsync<TState, TInput>(
             Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata, 
             CancellationToken cancellationToken = default)
@@ -699,7 +699,7 @@ namespace REstate.Remote.Services
             return await getSchematicAsync(request.SchematicName, GetCallCancellationToken());
         }
 
-        public virtual async Task<GetSchematicResponse> GetSchematicAsync<TState, TInput>(string schematicName, CancellationToken cancellationToken)
+        internal virtual async Task<GetSchematicResponse> GetSchematicAsync<TState, TInput>(string schematicName, CancellationToken cancellationToken)
         {
             var stateEngine = REstateHost.Agent
                 .AsLocal()
@@ -752,7 +752,7 @@ namespace REstate.Remote.Services
             return Nil.Default;
         }
 
-        public virtual async Task DeleteMachineAsync<TState, TInput>(string machineId, CancellationToken cancellationToken)
+        internal virtual async Task DeleteMachineAsync<TState, TInput>(string machineId, CancellationToken cancellationToken)
         {
             var stateEngine = REstateHost.Agent
                 .AsLocal()
@@ -762,7 +762,7 @@ namespace REstate.Remote.Services
         }
         #endregion DeleteMachineAsync
 
-        public virtual Type[] GetGenericsFromHeaders()
+        internal virtual Type[] GetGenericsFromHeaders()
         {
             return Context.CallContext.RequestHeaders
                 .Where(header => new[] { StateTypeHeaderKey, InputTypeHeaderKey }
@@ -784,7 +784,7 @@ namespace REstate.Remote.Services
             return (types[0], types[1]);
         }
 
-        public virtual CancellationToken GetCallCancellationToken()
+        internal virtual CancellationToken GetCallCancellationToken()
         {
             return Context.CallContext.CancellationToken;
         }

--- a/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
+++ b/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
@@ -9,13 +9,14 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using MagicOnion.Server;
 using Xunit;
 
 namespace REstate.Remote.Tests.Units
 {
     public class StateMachineServiceTests
     {
-        private Mock<StateMachineService> _stateMachineServiceMock;
+        private readonly Mock<StateMachineService> _stateMachineServiceMock;
 
         public StateMachineServiceTests()
         {
@@ -28,6 +29,20 @@ namespace REstate.Remote.Tests.Units
             _stateMachineServiceMock
                 .Setup(_ => _.GetCallCancellationToken())
                 .Returns(CancellationToken.None);
+        }
+
+        [Fact]
+        public void CanBuildServerServiceDefinition()
+        {
+            var service = MagicOnionEngine.BuildServerServiceDefinition(
+                targetTypes: new[]
+                {
+                    typeof(StateMachineService)
+                },
+                option: new MagicOnionOptions(
+                    isReturnExceptionStackTraceInErrorDetail: true));
+
+            Assert.NotNull(service);
         }
 
         [Fact]


### PR DESCRIPTION
### Description of the Change
In order to fix the MagicOnion gRPC ServiceDescriptor for StateMachineService:

- Change public virtual methods to internal virtual in StateMachineService
- Add internals visible to for REstate.Remote to REstate.Remote.Tests and Moq's DynamicProxyGenAssembly2
- Closes #9
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs
Moving the generics methods out of this class, but there is already an open issue #8 to track that effort. This just fixes it ASAP.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?
It is broken otherwise!
<!-- Explain why this functionality should be in REstate as opposed to a community package -->

### Benefits
MagicOnion gRPC Server works!
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
InternalsVisibleTo a dynamic assembly for Moq
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
