### PR TITLE
Change the ToString implementations on Machines and Schematics

### DIFF
--- a/src/REstate/Engine/DotGraphCartographer.cs
+++ b/src/REstate/Engine/DotGraphCartographer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using REstate.Schematics;
@@ -10,6 +11,10 @@ namespace REstate.Engine
     public class DotGraphCartographer<TState, TInput>
         : ICartographer<TState, TInput>
     {
+
+        private static readonly Lazy<DotGraphCartographer<TState, TInput>> InstanceLazy = new Lazy<DotGraphCartographer<TState,TInput>>();
+        public static DotGraphCartographer<TState, TInput> Instance => InstanceLazy.Value;
+
         /// <summary>
         /// Produces a DOT GraphViz graph.
         /// </summary>

--- a/src/REstate/Engine/REstateMachine.cs
+++ b/src/REstate/Engine/REstateMachine.cs
@@ -16,7 +16,6 @@ namespace REstate.Engine
     {
         private readonly IConnectorResolver<TState, TInput> _connectorResolver;
         private readonly IRepositoryContextFactory<TState, TInput> _repositoryContextFactory;
-        private readonly ICartographer<TState, TInput> _cartographer;
         private readonly IReadOnlyDictionary<string, string> _metadata;
         private readonly IReadOnlyCollection<IEventListener> _listeners;
 
@@ -31,7 +30,6 @@ namespace REstate.Engine
         {
             _connectorResolver = connectorResolver;
             _repositoryContextFactory = repositoryContextFactory;
-            _cartographer = cartographer;
             _metadata = metadata;
             _listeners = listeners.ToList();
 
@@ -198,6 +196,6 @@ namespace REstate.Engine
         }
 
         public override string ToString() =>
-            _cartographer.WriteMap(Schematic.States.Values);
+            $"{Schematic.SchematicName}/{MachineId}";
     }
 }

--- a/src/REstate/Schematics/Schematic.cs
+++ b/src/REstate/Schematics/Schematic.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using REstate.Engine;
 
 namespace REstate.Schematics
 {
@@ -31,5 +32,10 @@ namespace REstate.Schematics
                 c => (IState<TState, TInput>)c);
 
         public State<TState, TInput>[] States { get; set; }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString() => 
+            DotGraphCartographer<TState, TInput>.Instance.WriteMap(States);
     }
 }

--- a/test/REstate.Tests/Units/MachineTests.cs
+++ b/test/REstate.Tests/Units/MachineTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using REstate.Schematics;
+using Xunit;
+
+namespace REstate.Tests.Units
+{
+    public class MachineTests
+    {
+        [Fact]
+        public void Machine_has_correct_ToString_functionality()
+        {
+            // Arrange
+            var schematic = REstateHost.Agent
+                .CreateSchematic<string, string>("TestSchematic")
+                .WithState("Initial", state => state
+                    .AsInitialState())
+                .Build();
+
+            // Act
+            var machine = REstateHost.Agent
+                .GetStateEngine<string, string>()
+                .CreateMachineAsync(schematic).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.StartsWith($"{schematic.SchematicName}/", machine.ToString(), StringComparison.Ordinal);
+            Assert.EndsWith(machine.MachineId, machine.ToString(), StringComparison.Ordinal);
+        }
+    }
+}

--- a/test/REstate.Tests/Units/SchematicTests.cs
+++ b/test/REstate.Tests/Units/SchematicTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using REstate.Engine;
+using Xunit;
+
+namespace REstate.Tests.Units
+{
+    public class SchematicTests
+    {
+        [Fact]
+        public void Schematic_has_correct_ToString_functionality()
+        {
+            // Arrange
+            var schematic = REstateHost.Agent
+                .CreateSchematic<string, string>("Schematic")
+                .WithState("Initial", state => state
+                    .AsInitialState())
+                .Build();
+
+            // Act
+            var toString = schematic.ToString();
+
+            // Assert
+            Assert.NotNull(toString);
+            Assert.Equal(DotGraphCartographer<string, string>.Instance.WriteMap(schematic.States), toString);
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change
- Make singleton for DotGraphCartographer
- Schematic ToString should use DotGraphCartographer by default.
- Machine ToString should be SchematicName/MachineId for more useful information
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in REstate as opposed to a community package -->

### Benefits
Tests, debugging, and console prints become more useful.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Strictly using DotGraph on Schematics isn't very flexible if the user wants a different format. They will need to use the ICartographer interface instead.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
