### PR TITLE
Allow users to supply MachineIds when creating Machines

### DIFF
--- a/src/REstate.Engine.Repositories.Redis/RedisEngineRepository.cs
+++ b/src/REstate.Engine.Repositories.Redis/RedisEngineRepository.cs
@@ -53,20 +53,22 @@ namespace REstate.Engine.Repositories.Redis
 
         public async Task<MachineStatus<TState, TInput>> CreateMachineAsync(
             string schematicName,
+            string machineId,
             Metadata metadata,
             CancellationToken cancellationToken = default)
         {
             var schematic = await RetrieveSchematicAsync(schematicName, cancellationToken).ConfigureAwait(false);
 
-            return await CreateMachineAsync(schematic, metadata, cancellationToken).ConfigureAwait(false);
+            return await CreateMachineAsync(schematic, machineId, metadata, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<MachineStatus<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             Metadata metadata,
             CancellationToken cancellationToken = default)
         {
-            var machineId = Guid.NewGuid().ToString();
+            var id = machineId ?? Guid.NewGuid().ToString();
 
             var schematicBytes = LZ4MessagePackSerializer.Serialize(schematic, ContractlessStandardResolver.Instance);
 
@@ -84,7 +86,7 @@ namespace REstate.Engine.Repositories.Redis
 
             var record = new RedisMachineStatus<TState, TInput>
             {
-                MachineId = machineId,
+                MachineId = id,
                 SchematicHash = hash,
                 State = schematic.InitialState,
                 CommitTag = commitTag,

--- a/src/REstate.Remote/GrpcStateEngine.cs
+++ b/src/REstate.Remote/GrpcStateEngine.cs
@@ -38,10 +38,24 @@ namespace REstate.Remote
             ISchematic<TState, TInput> schematic,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
-            => CreateMachineAsync(schematic.Clone(), metadata, cancellationToken);
+            => CreateMachineAsync(schematic.Clone(), null, metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            ISchematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematic.Clone(), machineId, metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            Schematic<TState, TInput> schematic,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematic, null, metadata, cancellationToken);
 
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -50,14 +64,22 @@ namespace REstate.Remote
                 .CreateMachineFromSchematicAsync(new CreateMachineFromSchematicRequest
                 {
                     SchematicBytes = MessagePackSerializer.Serialize(schematic, ContractlessStandardResolver.Instance),
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             return new GrpcStateMachine<TState, TInput>(_stateMachineService, response.MachineId);
         }
 
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            string schematicName,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematicName, null, metadata, cancellationToken);
+
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             string schematicName,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -66,7 +88,8 @@ namespace REstate.Remote
                 .CreateMachineFromStoreAsync(new CreateMachineFromStoreRequest
                 {
                     SchematicName = schematicName,
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             return new GrpcStateMachine<TState, TInput>(_stateMachineService, response.MachineId);

--- a/src/REstate.Remote/Models/CreateMachine.cs
+++ b/src/REstate.Remote/Models/CreateMachine.cs
@@ -11,6 +11,9 @@ namespace REstate.Remote.Models
 
         [Key(1)]
         public IDictionary<string, string> Metadata { get; set; }
+
+        [Key(2)]
+        public string MachineId { get; set; }
     }
 
     [MessagePackObject]
@@ -21,6 +24,9 @@ namespace REstate.Remote.Models
 
         [Key(1)]
         public IDictionary<string, string> Metadata { get; set; }
+
+        [Key(2)]
+        public string MachineId { get; set; }
     }
 
     [MessagePackObject]

--- a/src/REstate/Engine/IStateEngine.cs
+++ b/src/REstate/Engine/IStateEngine.cs
@@ -22,6 +22,24 @@ namespace REstate.Engine
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default);
 
+        Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            Schematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default);
+
+        Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            ISchematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default);
+
+        Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            string schematicName,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default);
+
         Task BulkCreateMachinesAsync(
             Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,

--- a/src/REstate/Engine/Repositories/IMachineRepository.cs
+++ b/src/REstate/Engine/Repositories/IMachineRepository.cs
@@ -8,9 +8,9 @@ namespace REstate.Engine.Repositories
 {
     public interface IMachineRepository<TState, TInput>
     {
-        Task<MachineStatus<TState, TInput>> CreateMachineAsync(string schematicName, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
+        Task<MachineStatus<TState, TInput>> CreateMachineAsync(string schematicName, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
 
-        Task<MachineStatus<TState, TInput>> CreateMachineAsync(Schematic<TState, TInput> schematic, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
+        Task<MachineStatus<TState, TInput>> CreateMachineAsync(Schematic<TState, TInput> schematic, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
 
         Task<ICollection<MachineStatus<TState, TInput>>> BulkCreateMachinesAsync(Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,

--- a/src/REstate/Engine/Repositories/InMemory/EngineRepository.cs
+++ b/src/REstate/Engine/Repositories/InMemory/EngineRepository.cs
@@ -39,25 +39,27 @@ namespace REstate.Engine.Repositories.InMemory
         }
 
         public Task<MachineStatus<TState, TInput>> CreateMachineAsync(
-            string schematicName, 
+            string schematicName,
+            string machineId,
             Metadata metadata, 
             CancellationToken cancellationToken = default)
         {
             var schematic = Schematics[schematicName];
 
-            return CreateMachineAsync(schematic, metadata, cancellationToken);
+            return CreateMachineAsync(schematic, machineId, metadata, cancellationToken);
         }
 
         public Task<MachineStatus<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             Metadata metadata, 
             CancellationToken cancellationToken = default)
         {
-            var machineId = Guid.NewGuid().ToString();
+            var id = machineId ?? Guid.NewGuid().ToString();
 
             var record = new MachineStatus<TState, TInput>
             {
-                MachineId = machineId,
+                MachineId = id,
                 Schematic = schematic,
                 State = schematic.InitialState,
                 CommitTag = Guid.NewGuid(),
@@ -65,7 +67,7 @@ namespace REstate.Engine.Repositories.InMemory
                 Metadata = metadata
             };
 
-            Machines.Add(machineId, (record, metadata));
+            Machines.Add(id, (record, metadata));
 
             return Task.FromResult(record);
         }

--- a/src/REstate/Engine/StateEngine.cs
+++ b/src/REstate/Engine/StateEngine.cs
@@ -77,8 +77,15 @@ namespace REstate.Engine
             CancellationToken cancellationToken = default)
             => StoreSchematicAsync(schematic.Clone(), cancellationToken);
 
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            Schematic<TState, TInput> schematic,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default) 
+            => CreateMachineAsync(schematic, null, metadata, cancellationToken);
+
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -90,6 +97,7 @@ namespace REstate.Engine
                 newMachineStatus = await repositories.Machines
                     .CreateMachineAsync(
                         schematic,
+                        machineId,
                         metadata,
                         cancellationToken)
                     .ConfigureAwait(false);
@@ -134,10 +142,24 @@ namespace REstate.Engine
             ISchematic<TState, TInput> schematic,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematic, null, metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            ISchematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
             => CreateMachineAsync(schematic.Clone(), metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            string schematicName,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematicName, null, metadata, cancellationToken);
 
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             string schematicName,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -155,6 +177,7 @@ namespace REstate.Engine
                 newMachineStatus = await repositories.Machines
                     .CreateMachineAsync(
                         schematicName,
+                        machineId,
                         metadata,
                         cancellationToken)
                     .ConfigureAwait(false);

--- a/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
+++ b/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
@@ -237,6 +237,7 @@ namespace REstate.Remote.Tests.Units
             _stateMachineServiceMock
                 .Setup(_ => _.CreateMachineFromStoreAsync<string, string>(
                     It.Is<string>(it => it == schematicName),
+                    It.Is<string>(it => it == machineId),
                     It.Is<IDictionary<string, string>>(it => it[key] == metadata[key]),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CreateMachineResponse
@@ -249,7 +250,8 @@ namespace REstate.Remote.Tests.Units
                 .CreateMachineFromStoreAsync(new CreateMachineFromStoreRequest
                 {
                     SchematicName = schematicName,
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             //Assert
@@ -261,7 +263,12 @@ namespace REstate.Remote.Tests.Units
         public async Task CreateMachineFromSchematicAsync()
         {
             // Arrange
-            var schematic = new Schematic<string, string> { SchematicName = "schematic name" };
+            var schematic = new Schematic<string, string>
+            {
+                SchematicName = "schematic name",
+                InitialState = "initial state",
+                States = new State<string, string>[] { new State<string, string> { Value = "initial state" } }
+            };
             var schematicBytes = MessagePackSerializer.Serialize(schematic, ContractlessStandardResolver.Instance);
             var key = "key";
             var value = "value";
@@ -271,6 +278,7 @@ namespace REstate.Remote.Tests.Units
             _stateMachineServiceMock
                 .Setup(_ => _.CreateMachineFromSchematicAsync(
                     It.Is<Schematic<string, string>>(it => it.SchematicName == schematic.SchematicName),
+                    It.Is<string>(it => it == machineId),
                     It.Is<IDictionary<string, string>>(it => it[key] == metadata[key]),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CreateMachineResponse
@@ -283,7 +291,8 @@ namespace REstate.Remote.Tests.Units
                 .CreateMachineFromSchematicAsync(new CreateMachineFromSchematicRequest
                 {
                     SchematicBytes = schematicBytes,
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             // Assert


### PR DESCRIPTION
### Description of the Change
Allow users to supply MachineIds when creating Machines

- Add overloads on StateEngine to accept MachineId
- Change repositories to accept MachineId
- Update related tests
- Closes #17  

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in REstate as opposed to a community package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
