### PR TITLE
Allow predefined machine id on machine creation

### DIFF
--- a/src/REstate.Engine.Repositories.Redis/RedisEngineRepository.cs
+++ b/src/REstate.Engine.Repositories.Redis/RedisEngineRepository.cs
@@ -53,20 +53,22 @@ namespace REstate.Engine.Repositories.Redis
 
         public async Task<MachineStatus<TState, TInput>> CreateMachineAsync(
             string schematicName,
+            string machineId,
             Metadata metadata,
             CancellationToken cancellationToken = default)
         {
             var schematic = await RetrieveSchematicAsync(schematicName, cancellationToken).ConfigureAwait(false);
 
-            return await CreateMachineAsync(schematic, metadata, cancellationToken).ConfigureAwait(false);
+            return await CreateMachineAsync(schematic, machineId, metadata, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<MachineStatus<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             Metadata metadata,
             CancellationToken cancellationToken = default)
         {
-            var machineId = Guid.NewGuid().ToString();
+            var id = machineId ?? Guid.NewGuid().ToString();
 
             var schematicBytes = LZ4MessagePackSerializer.Serialize(schematic, ContractlessStandardResolver.Instance);
 
@@ -84,7 +86,7 @@ namespace REstate.Engine.Repositories.Redis
 
             var record = new RedisMachineStatus<TState, TInput>
             {
-                MachineId = machineId,
+                MachineId = id,
                 SchematicHash = hash,
                 State = schematic.InitialState,
                 CommitTag = commitTag,

--- a/src/REstate.Remote/GrpcStateEngine.cs
+++ b/src/REstate.Remote/GrpcStateEngine.cs
@@ -38,10 +38,24 @@ namespace REstate.Remote
             ISchematic<TState, TInput> schematic,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
-            => CreateMachineAsync(schematic.Clone(), metadata, cancellationToken);
+            => CreateMachineAsync(schematic.Clone(), null, metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            ISchematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematic.Clone(), machineId, metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            Schematic<TState, TInput> schematic,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematic, null, metadata, cancellationToken);
 
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -50,14 +64,22 @@ namespace REstate.Remote
                 .CreateMachineFromSchematicAsync(new CreateMachineFromSchematicRequest
                 {
                     SchematicBytes = MessagePackSerializer.Serialize(schematic, ContractlessStandardResolver.Instance),
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             return new GrpcStateMachine<TState, TInput>(_stateMachineService, response.MachineId);
         }
 
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            string schematicName,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematicName, null, metadata, cancellationToken);
+
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             string schematicName,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -66,7 +88,8 @@ namespace REstate.Remote
                 .CreateMachineFromStoreAsync(new CreateMachineFromStoreRequest
                 {
                     SchematicName = schematicName,
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             return new GrpcStateMachine<TState, TInput>(_stateMachineService, response.MachineId);

--- a/src/REstate.Remote/Models/CreateMachine.cs
+++ b/src/REstate.Remote/Models/CreateMachine.cs
@@ -11,6 +11,9 @@ namespace REstate.Remote.Models
 
         [Key(1)]
         public IDictionary<string, string> Metadata { get; set; }
+
+        [Key(2)]
+        public string MachineId { get; set; }
     }
 
     [MessagePackObject]
@@ -21,6 +24,9 @@ namespace REstate.Remote.Models
 
         [Key(1)]
         public IDictionary<string, string> Metadata { get; set; }
+
+        [Key(2)]
+        public string MachineId { get; set; }
     }
 
     [MessagePackObject]

--- a/src/REstate.Remote/REstate.Remote.csproj
+++ b/src/REstate.Remote/REstate.Remote.csproj
@@ -15,7 +15,7 @@
     <Description>Provides gRPC/HTTP2 interconnect support for REstate's engine in either client or server configuration.</Description>
     <Copyright>Ovan Crone 2016</Copyright>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/REstate/Engine/IStateEngine.cs
+++ b/src/REstate/Engine/IStateEngine.cs
@@ -22,6 +22,24 @@ namespace REstate.Engine
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default);
 
+        Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            Schematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default);
+
+        Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            ISchematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default);
+
+        Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            string schematicName,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default);
+
         Task BulkCreateMachinesAsync(
             Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,

--- a/src/REstate/Engine/Repositories/IMachineRepository.cs
+++ b/src/REstate/Engine/Repositories/IMachineRepository.cs
@@ -8,9 +8,9 @@ namespace REstate.Engine.Repositories
 {
     public interface IMachineRepository<TState, TInput>
     {
-        Task<MachineStatus<TState, TInput>> CreateMachineAsync(string schematicName, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
+        Task<MachineStatus<TState, TInput>> CreateMachineAsync(string schematicName, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
 
-        Task<MachineStatus<TState, TInput>> CreateMachineAsync(Schematic<TState, TInput> schematic, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
+        Task<MachineStatus<TState, TInput>> CreateMachineAsync(Schematic<TState, TInput> schematic, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
 
         Task<ICollection<MachineStatus<TState, TInput>>> BulkCreateMachinesAsync(Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,

--- a/src/REstate/Engine/Repositories/InMemory/EngineRepository.cs
+++ b/src/REstate/Engine/Repositories/InMemory/EngineRepository.cs
@@ -39,25 +39,27 @@ namespace REstate.Engine.Repositories.InMemory
         }
 
         public Task<MachineStatus<TState, TInput>> CreateMachineAsync(
-            string schematicName, 
+            string schematicName,
+            string machineId,
             Metadata metadata, 
             CancellationToken cancellationToken = default)
         {
             var schematic = Schematics[schematicName];
 
-            return CreateMachineAsync(schematic, metadata, cancellationToken);
+            return CreateMachineAsync(schematic, machineId, metadata, cancellationToken);
         }
 
         public Task<MachineStatus<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             Metadata metadata, 
             CancellationToken cancellationToken = default)
         {
-            var machineId = Guid.NewGuid().ToString();
+            var id = machineId ?? Guid.NewGuid().ToString();
 
             var record = new MachineStatus<TState, TInput>
             {
-                MachineId = machineId,
+                MachineId = id,
                 Schematic = schematic,
                 State = schematic.InitialState,
                 CommitTag = Guid.NewGuid(),
@@ -65,7 +67,7 @@ namespace REstate.Engine.Repositories.InMemory
                 Metadata = metadata
             };
 
-            Machines.Add(machineId, (record, metadata));
+            Machines.Add(id, (record, metadata));
 
             return Task.FromResult(record);
         }

--- a/src/REstate/Engine/StateEngine.cs
+++ b/src/REstate/Engine/StateEngine.cs
@@ -77,8 +77,15 @@ namespace REstate.Engine
             CancellationToken cancellationToken = default)
             => StoreSchematicAsync(schematic.Clone(), cancellationToken);
 
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            Schematic<TState, TInput> schematic,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default) 
+            => CreateMachineAsync(schematic, null, metadata, cancellationToken);
+
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             Schematic<TState, TInput> schematic,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -90,6 +97,7 @@ namespace REstate.Engine
                 newMachineStatus = await repositories.Machines
                     .CreateMachineAsync(
                         schematic,
+                        machineId,
                         metadata,
                         cancellationToken)
                     .ConfigureAwait(false);
@@ -134,10 +142,24 @@ namespace REstate.Engine
             ISchematic<TState, TInput> schematic,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematic, null, metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            ISchematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
             => CreateMachineAsync(schematic.Clone(), metadata, cancellationToken);
+
+        public Task<IStateMachine<TState, TInput>> CreateMachineAsync(
+            string schematicName,
+            IDictionary<string, string> metadata = null,
+            CancellationToken cancellationToken = default)
+            => CreateMachineAsync(schematicName, null, metadata, cancellationToken);
 
         public async Task<IStateMachine<TState, TInput>> CreateMachineAsync(
             string schematicName,
+            string machineId,
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default)
         {
@@ -155,6 +177,7 @@ namespace REstate.Engine
                 newMachineStatus = await repositories.Machines
                     .CreateMachineAsync(
                         schematicName,
+                        machineId,
                         metadata,
                         cancellationToken)
                     .ConfigureAwait(false);

--- a/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
+++ b/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
@@ -237,7 +237,7 @@ namespace REstate.Remote.Tests.Units
             _stateMachineServiceMock
                 .Setup(_ => _.CreateMachineFromStoreAsync<string, string>(
                     It.Is<string>(it => it == schematicName),
-                    It.Is<string>(it => it == machineId),
+                    machineId,
                     It.Is<IDictionary<string, string>>(it => it[key] == metadata[key]),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CreateMachineResponse
@@ -278,7 +278,7 @@ namespace REstate.Remote.Tests.Units
             _stateMachineServiceMock
                 .Setup(_ => _.CreateMachineFromSchematicAsync(
                     It.Is<Schematic<string, string>>(it => it.SchematicName == schematic.SchematicName),
-                    It.Is<string>(it => it == machineId),
+                    machineId,
                     It.Is<IDictionary<string, string>>(it => it[key] == metadata[key]),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CreateMachineResponse
@@ -346,7 +346,7 @@ namespace REstate.Remote.Tests.Units
             {
                 SchematicName = "schematic name",
                 InitialState = "initial state",
-                States = new State<string, string>[] { new State<string, string> { Value = "initial state" } }
+                States = new[] { new State<string, string> { Value = "initial state" } }
             };
             var schematicBytes = MessagePackSerializer.Serialize(schematic, ContractlessStandardResolver.Instance);
             var metadataEnumerable = new List<Dictionary<string, string>>();

--- a/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
+++ b/test/REstate.Remote.Tests/Units/StateMachineServiceTests.cs
@@ -237,6 +237,7 @@ namespace REstate.Remote.Tests.Units
             _stateMachineServiceMock
                 .Setup(_ => _.CreateMachineFromStoreAsync<string, string>(
                     It.Is<string>(it => it == schematicName),
+                    It.Is<string>(it => it == machineId),
                     It.Is<IDictionary<string, string>>(it => it[key] == metadata[key]),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CreateMachineResponse
@@ -249,7 +250,8 @@ namespace REstate.Remote.Tests.Units
                 .CreateMachineFromStoreAsync(new CreateMachineFromStoreRequest
                 {
                     SchematicName = schematicName,
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             //Assert
@@ -261,7 +263,12 @@ namespace REstate.Remote.Tests.Units
         public async Task CreateMachineFromSchematicAsync()
         {
             // Arrange
-            var schematic = new Schematic<string, string> { SchematicName = "schematic name" };
+            var schematic = new Schematic<string, string>
+            {
+                SchematicName = "schematic name",
+                InitialState = "initial state",
+                States = new State<string, string>[] { new State<string, string> { Value = "initial state" } }
+            };
             var schematicBytes = MessagePackSerializer.Serialize(schematic, ContractlessStandardResolver.Instance);
             var key = "key";
             var value = "value";
@@ -271,6 +278,7 @@ namespace REstate.Remote.Tests.Units
             _stateMachineServiceMock
                 .Setup(_ => _.CreateMachineFromSchematicAsync(
                     It.Is<Schematic<string, string>>(it => it.SchematicName == schematic.SchematicName),
+                    It.Is<string>(it => it == machineId),
                     It.Is<IDictionary<string, string>>(it => it[key] == metadata[key]),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CreateMachineResponse
@@ -283,7 +291,8 @@ namespace REstate.Remote.Tests.Units
                 .CreateMachineFromSchematicAsync(new CreateMachineFromSchematicRequest
                 {
                     SchematicBytes = schematicBytes,
-                    Metadata = metadata
+                    Metadata = metadata,
+                    MachineId = machineId
                 });
 
             // Assert

--- a/test/REstate.Tests/Features/Context/Machines.cs
+++ b/test/REstate.Tests/Features/Context/Machines.cs
@@ -15,11 +15,24 @@ namespace REstate.Tests.Features.Context
                 .CreateMachineAsync(schematic).GetAwaiter().GetResult();
         }
 
+        public void When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(
+            Schematic<TState, TInput> schematic, string machineId)
+        {
+            CurrentMachine = CurrentHost.Agent()
+                .GetStateEngine<TState, TInput>()
+                .CreateMachineAsync(schematic, machineId).GetAwaiter().GetResult();
+        }
+
         public void Then_the_Machine_is_created_successfully(IStateMachine<TState, TInput> machine)
         {
             Assert.NotNull(machine);
             Assert.NotNull(machine.MachineId);
             Assert.NotEmpty(machine.MachineId);
+        }
+
+        public void Then_the_MachineId_is_MACHINEID(IStateMachine<TState, TInput> machine, string machineId)
+        {
+            Assert.Equal(machineId, CurrentMachine.MachineId);
         }
     }
 }

--- a/test/REstate.Tests/Features/Context/Machines.cs
+++ b/test/REstate.Tests/Features/Context/Machines.cs
@@ -15,12 +15,27 @@ namespace REstate.Tests.Features.Context
                 .CreateMachineAsync(schematic).GetAwaiter().GetResult();
         }
 
+        public void When_a_Machine_is_created_from_a_SchematicName(string schematicName)
+        {
+            CurrentMachine = CurrentHost.Agent()
+                .GetStateEngine<TState, TInput>()
+                .CreateMachineAsync(schematicName).GetAwaiter().GetResult();
+        }
+
         public void When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(
             Schematic<TState, TInput> schematic, string machineId)
         {
             CurrentMachine = CurrentHost.Agent()
                 .GetStateEngine<TState, TInput>()
                 .CreateMachineAsync(schematic, machineId).GetAwaiter().GetResult();
+        }
+
+        public void When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(
+            string schematicName, string machineId)
+        {
+            CurrentMachine = CurrentHost.Agent()
+                .GetStateEngine<TState, TInput>()
+                .CreateMachineAsync(schematicName, machineId).GetAwaiter().GetResult();
         }
 
         public void Then_the_Machine_is_created_successfully(IStateMachine<TState, TInput> machine)

--- a/test/REstate.Tests/Features/Context/Schematics.cs
+++ b/test/REstate.Tests/Features/Context/Schematics.cs
@@ -8,13 +8,20 @@ namespace REstate.Tests.Features.Context
     {
         public Schematic<TState, TInput> CurrentSchematic { get; set; }
 
-        public void Given_a_simple_schematic_with_an_initial_state_INITIALSTATE(TState initialState)
+        public void Given_a_Schematic_with_an_initial_state_INITIALSTATE(string schematicName, TState initialState)
         {
             CurrentSchematic = CurrentHost.Agent()
-                .CreateSchematic<TState, TInput>("simple")
+                .CreateSchematic<TState, TInput>(schematicName)
                 .WithState(initialState, state => state
                     .AsInitialState())
                 .Build();
+        }
+
+        public void Given_a_Schematic_is_stored(Schematic<TState, TInput> schematic)
+        {
+            CurrentHost.Agent()
+                .GetStateEngine<TState, TInput>()
+                .StoreSchematicAsync(schematic).GetAwaiter().GetResult();
         }
     }
 }

--- a/test/REstate.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Tests/Features/MachineCreation.cs
@@ -1,4 +1,5 @@
-﻿using LightBDD.Framework;
+﻿using System.Reflection;
+using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
 using LightBDD.XUnit2;
@@ -17,28 +18,58 @@ I want to create machines from schematics")]
     public class MachineCreation
         : FeatureFixture
     {
-
         [Scenario]
         public void A_machine_can_be_created_from_a_Schematic()
         {
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+
             Runner.WithContext<REstateContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_simple_schematic_with_an_initial_state_INITIALSTATE("Initial"),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.When_a_Machine_is_created_from_a_Schematic(_.CurrentSchematic),
+                _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine));
+        }
+
+        [Scenario]
+        public void A_machine_can_be_created_from_a_SchematicName()
+        {
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+
+            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
+                _ => _.When_a_Machine_is_created_from_a_SchematicName(_.CurrentSchematic.SchematicName),
                 _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine));
         }
 
         [Scenario]
         public void A_machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
         {
-            var machineId = "12345";
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+            var machineId = MethodBase.GetCurrentMethod().Name;
 
             Runner.WithContext<REstateContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_simple_schematic_with_an_initial_state_INITIALSTATE("Initial"),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(_.CurrentSchematic, machineId),
                 _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine),
                 _=> _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
+        }
+
+        [Scenario]
+        public void A_machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
+        {
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+            var machineId = MethodBase.GetCurrentMethod().Name;
+
+            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
+                _ => _.When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(_.CurrentSchematic.SchematicName, machineId),
+                _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine),
+                _ => _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
         }
 
         #region Constructor

--- a/test/REstate.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Tests/Features/MachineCreation.cs
@@ -19,7 +19,7 @@ I want to create machines from schematics")]
     {
 
         [Scenario]
-        public void A_simple_machine_can_be_created()
+        public void A_machine_can_be_created_from_a_Schematic()
         {
             Runner.WithContext<REstateContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
@@ -28,17 +28,18 @@ I want to create machines from schematics")]
                 _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine));
         }
 
-        // Given a default host
-        // And Given a schematic
-        // When I create a Machine
-        // Then the Machine is not null
-        // Then the Machine has an Id
+        [Scenario]
+        public void A_machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
+        {
+            var machineId = "12345";
 
-        // Given a default host
-        // And Given a schematic
-        // When I create a Machine with an Id
-        // Then the Machine is not null
-        // Then the Machine has the same Id
+            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.Given_a_simple_schematic_with_an_initial_state_INITIALSTATE("Initial"),
+                _ => _.When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(_.CurrentSchematic, machineId),
+                _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine),
+                _=> _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
+        }
 
         #region Constructor
         public MachineCreation(ITestOutputHelper output)


### PR DESCRIPTION
### Description of the Change
Allow users to supply MachineIds when creating Machines

- Add overloads on StateEngine to accept MachineId
- Change repositories to accept MachineId
- Update related tests
- Add machineId parameter tests for MachineCreation
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?
Requested by developer team lead, needed for adoption.
<!-- Explain why this functionality should be in REstate as opposed to a community package -->

### Benefits
Allows an existing identifier to be used, so the developer doesn't have to ALSO store and track REstate's Ids.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Possibly some downstream performance impact on repositories where Id sorting matters, but that is a choice for each developer to make.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#17 
<!-- Enter any applicable Issues here -->
