### PR TITLE
Add tests for Remote Machine creation

### DIFF
--- a/src/REstate.Remote/Services/StateMachineService.cs
+++ b/src/REstate.Remote/Services/StateMachineService.cs
@@ -89,7 +89,7 @@ namespace REstate.Remote.Services
         private const string InputTypeHeaderKey = "Input-Type";
         private const Type NoPayloadType = null;
 
-        private static readonly ConcurrentDictionary<MethodKey, Delegate> DelegateCache =
+        private readonly ConcurrentDictionary<MethodKey, Delegate> DelegateCache =
             new ConcurrentDictionary<MethodKey, Delegate>();
 
         #region SendAsync

--- a/test/REstate.Remote.Tests/Features/Context/REstateRemoteContext.cs
+++ b/test/REstate.Remote.Tests/Features/Context/REstateRemoteContext.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Grpc.Core;
+using REstate.Tests.Features.Context;
+
+namespace REstate.Remote.Tests.Features.Context
+{
+    using static SharedRemoteContext;
+
+    public static class SharedRemoteContext
+    {
+        public static REstateGrpcServer CurrentGrpcServer { get; set; }
+
+        public static object CurrentGrpcServerSyncRoot = new object();
+    }
+
+    public class REstateRemoteContext<TState, TInput>
+        : REstateContext<TState, TInput>
+    {
+        public void Given_a_REstate_gRPC_Server_running_on_the_default_endpoint()
+        {
+            if(CurrentGrpcServer != null) return;
+
+            lock (CurrentGrpcServerSyncRoot)
+            {
+                if(CurrentGrpcServer != null) return;
+
+                CurrentGrpcServer = CurrentHost.Agent()
+                    .AsRemote()
+                    .CreateGrpcServer(new ServerPort("0.0.0.0", 12345, ServerCredentials.Insecure));
+
+                CurrentGrpcServer.Start();
+            }
+            
+        }
+
+        public void Given_the_default_agent_is_gRPC_remote_on_default_endpoint()
+        {
+            CurrentHost.Agent().Configuration
+                .RegisterComponent(new GrpcRemoteHostComponent(new GrpcHostOptions
+                {
+                    Channel = new Channel("localhost", 12345, ChannelCredentials.Insecure),
+                    UseAsDefaultEngine = true
+                }));
+        }
+    }
+}

--- a/test/REstate.Remote.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Remote.Tests/Features/MachineCreation.cs
@@ -1,0 +1,94 @@
+﻿using System.Reflection;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios.Contextual;
+using LightBDD.Framework.Scenarios.Extended;
+using LightBDD.XUnit2;
+using REstate.Remote.Tests.Features.Context;
+using Xunit.Abstractions;
+
+// ReSharper disable InconsistentNaming
+
+namespace REstate.Remote.Tests.Features
+{
+    [FeatureDescription(@"
+In order to support cloud scaling
+As a developer
+I want to create Machines from Schematics on a remote server")]
+    [ScenarioCategory("Machine Creation")]
+    [ScenarioCategory("Remote")]
+    public class MachineCreation
+        : FeatureFixture
+    {
+        [Scenario]
+        public void A_machine_can_be_created_from_a_Schematic()
+        {
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+
+            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
+                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.When_a_Machine_is_created_from_a_Schematic(_.CurrentSchematic),
+                _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine));
+        }
+
+        [Scenario]
+        public void A_machine_can_be_created_from_a_SchematicName()
+        {
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+
+            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
+                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
+                _ => _.When_a_Machine_is_created_from_a_SchematicName(_.CurrentSchematic.SchematicName),
+                _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine));
+        }
+
+        [Scenario]
+        public void A_machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
+        {
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+            var machineId = MethodBase.GetCurrentMethod().Name;
+
+            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
+                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(_.CurrentSchematic, machineId),
+                _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine),
+                _=> _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
+        }
+
+        [Scenario]
+        public void A_machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
+        {
+            var schematicName = MethodBase.GetCurrentMethod().Name;
+            var machineId = MethodBase.GetCurrentMethod().Name;
+
+            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
+                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
+                _ => _.When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(_.CurrentSchematic.SchematicName, machineId),
+                _ => _.Then_the_Machine_is_created_successfully(_.CurrentMachine),
+                _ => _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
+        }
+
+        #region Constructor
+        public MachineCreation(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+        #endregion
+    }
+
+
+}
+

--- a/test/REstate.Remote.Tests/REstate.Remote.Tests.csproj
+++ b/test/REstate.Remote.Tests/REstate.Remote.Tests.csproj
@@ -15,12 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Features\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\REstate.Remote\REstate.Remote.csproj" />
     <ProjectReference Include="..\..\src\REstate\REstate.csproj" />
+    <ProjectReference Include="..\REstate.Tests\REstate.Tests.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of the Change
:white_check_mark: Add tests for Remote Machine creation
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in REstate as opposed to a community package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
- Make DelegateCache instance instead of static on StateMachineService. This was causing an issue where mock delegates were being cached and so scenario tests would fail. Investigate changing that back after issue #8 is resolved.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#8
<!-- Enter any applicable Issues here -->
