### PR TITLE
Move StateMachineService local Agent to a new interface

### DIFF
--- a/src/REstate.Remote/Services/IStateMachineService.cs
+++ b/src/REstate.Remote/Services/IStateMachineService.cs
@@ -1,0 +1,32 @@
+﻿using MagicOnion;
+using MessagePack;
+using REstate.Remote.Models;
+
+namespace REstate.Remote.Services
+{
+    public interface IStateMachineService
+        : IService<IStateMachineService>
+    {
+        UnaryResult<SendResponse> SendAsync(SendRequest request);
+
+        UnaryResult<SendResponse> SendWithPayloadAsync(SendWithPayloadRequest request);
+
+        UnaryResult<StoreSchematicResponse> StoreSchematicAsync(StoreSchematicRequest request);
+
+        UnaryResult<GetMachineSchematicResponse> GetMachineSchematicAsync(GetMachineSchematicRequest request);
+
+        UnaryResult<GetMachineMetadataResponse> GetMachineMetadataAsync(GetMachineMetadataRequest request);
+
+        UnaryResult<GetSchematicResponse> GetSchematicAsync(GetSchematicRequest request);
+
+        UnaryResult<Nil> DeleteMachineAsync(DeleteMachineRequest request);
+
+        UnaryResult<CreateMachineResponse> CreateMachineFromStoreAsync(CreateMachineFromStoreRequest request);
+
+        UnaryResult<CreateMachineResponse> CreateMachineFromSchematicAsync(CreateMachineFromSchematicRequest request);
+
+        UnaryResult<Nil> BulkCreateMachineFromStoreAsync(BulkCreateMachineFromStoreRequest request);
+
+        UnaryResult<Nil> BulkCreateMachineFromSchematicAsync(BulkCreateMachineFromSchematicRequest request);
+    }
+}

--- a/src/REstate.Remote/Services/IStateMachineServiceClient.cs
+++ b/src/REstate.Remote/Services/IStateMachineServiceClient.cs
@@ -1,0 +1,7 @@
+﻿namespace REstate.Remote.Services
+{
+    public interface IStateMachineServiceClient
+    {
+        IStateMachineService Create();
+    }
+}

--- a/src/REstate.Remote/Services/IStateMachineServiceLocalAdapter.cs
+++ b/src/REstate.Remote/Services/IStateMachineServiceLocalAdapter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using REstate.Remote.Models;
+using REstate.Schematics;
+
+namespace REstate.Remote.Services
+{
+    internal interface IStateMachineServiceLocalAdapter
+    {
+        Task BulkCreateMachineFromSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, IEnumerable<IDictionary<string, string>> metadata, CancellationToken cancellationToken = default);
+        Task BulkCreateMachineFromStoreAsync<TState, TInput>(string schematicName, IEnumerable<IDictionary<string, string>> metadata, CancellationToken cancellationToken = default);
+        Task<CreateMachineResponse> CreateMachineFromSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
+        Task<CreateMachineResponse> CreateMachineFromStoreAsync<TState, TInput>(string schematicName, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
+        Task DeleteMachineAsync<TState, TInput>(string machineId, CancellationToken cancellationToken);
+        Task<GetMachineMetadataResponse> GetMachineMetadataAsync<TState, TInput>(string machineId, CancellationToken cancellationToken = default);
+        Task<GetMachineSchematicResponse> GetMachineSchematicAsync<TState, TInput>(string machineId, CancellationToken cancellationToken = default);
+        Task<GetSchematicResponse> GetSchematicAsync<TState, TInput>(string schematicName, CancellationToken cancellationToken);
+        Task<SendResponse> SendAsync<TState, TInput>(string machineId, TInput input, Guid? commitTag, CancellationToken cancellationToken = default);
+        Task<SendResponse> SendWithPayloadAsync<TState, TInput, TPayload>(string machineId, TInput input, TPayload payload, Guid? commitTag, CancellationToken cancellationToken = default);
+        Task<StoreSchematicResponse> StoreSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/REstate.Remote/Services/StateMachineServiceClient.cs
+++ b/src/REstate.Remote/Services/StateMachineServiceClient.cs
@@ -1,0 +1,18 @@
+﻿using MagicOnion.Client;
+
+namespace REstate.Remote.Services
+{
+    public class StateMachineServiceClient
+        : IStateMachineServiceClient
+    {
+        private readonly GrpcHostOptions _gRpcHostOptions;
+
+        public StateMachineServiceClient(GrpcHostOptions gRpcHostOptions)
+        {
+            _gRpcHostOptions = gRpcHostOptions;
+        }
+
+        public IStateMachineService Create() =>
+            MagicOnionClient.Create<IStateMachineService>(_gRpcHostOptions.Channel);
+    }
+}

--- a/src/REstate.Remote/Services/StateMachineServiceLocalAdapter.cs
+++ b/src/REstate.Remote/Services/StateMachineServiceLocalAdapter.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using MagicOnion;
+using MessagePack;
+using MessagePack.Resolvers;
+using REstate.Engine;
+using REstate.Remote.Models;
+using REstate.Schematics;
+
+namespace REstate.Remote.Services
+{
+    public class StateMachineServiceLocalAdapter
+        : IStateMachineServiceLocalAdapter
+    {
+        public async Task<SendResponse> SendAsync<TState, TInput>(
+            string machineId,
+            TInput input,
+            Guid? commitTag,
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent.AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var machine = await engine.GetMachineAsync(machineId, cancellationToken).ConfigureAwait(false);
+
+            Status<TState> newStatus;
+
+            try
+            {
+                newStatus = commitTag != null
+                    ? await machine.SendAsync(input, commitTag.Value, cancellationToken).ConfigureAwait(false)
+                    : await machine.SendAsync(input, cancellationToken).ConfigureAwait(false);
+            }
+            catch (StateConflictException conflictException)
+            {
+                throw new ReturnStatusException(StatusCode.AlreadyExists, conflictException.Message);
+            }
+
+            return new SendResponse
+            {
+                MachineId = machineId,
+                CommitTag = newStatus.CommitTag,
+                StateBytes = MessagePackSerializer.Serialize(newStatus.State, ContractlessStandardResolver.Instance)
+            };
+        }
+
+        public async Task<SendResponse> SendWithPayloadAsync<TState, TInput, TPayload>(
+            string machineId, 
+            TInput input, 
+            TPayload payload, 
+            Guid? commitTag, 
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent.AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var machine = await engine.GetMachineAsync(machineId, cancellationToken).ConfigureAwait(false);
+
+            Status<TState> newStatus;
+
+            try
+            {
+                newStatus = commitTag != null
+                    ? await machine.SendAsync(input, payload, commitTag.Value, cancellationToken).ConfigureAwait(false)
+                    : await machine.SendAsync(input, payload, cancellationToken).ConfigureAwait(false);
+            }
+            catch (StateConflictException conflictException)
+            {
+                throw new ReturnStatusException(StatusCode.AlreadyExists, conflictException.Message);
+            }
+
+            return new SendResponse
+            {
+                MachineId = machineId,
+                CommitTag = newStatus.CommitTag,
+                StateBytes = MessagePackSerializer.Serialize(newStatus.State, ContractlessStandardResolver.Instance),
+                UpdatedTime = newStatus.UpdatedTime
+            };
+        }
+
+        public async Task<StoreSchematicResponse> StoreSchematicAsync<TState, TInput>(
+            Schematic<TState, TInput> schematic, 
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent.AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var newSchematic = await engine.StoreSchematicAsync(schematic, cancellationToken).ConfigureAwait(false);
+
+            return new StoreSchematicResponse
+            {
+                SchematicBytes = MessagePackSerializer.NonGeneric.Serialize(
+                    newSchematic.GetType(), 
+                    newSchematic, 
+                    ContractlessStandardResolver.Instance)
+            };
+        }
+
+        public async Task<GetMachineSchematicResponse> GetMachineSchematicAsync<TState, TInput>(
+            string machineId, 
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var machine = await engine.GetMachineAsync(machineId, cancellationToken).ConfigureAwait(false);
+
+            var schematic = await machine.GetSchematicAsync(cancellationToken).ConfigureAwait(false);
+
+            return new GetMachineSchematicResponse
+            {
+                MachineId = machine.MachineId,
+                SchematicBytes = MessagePackSerializer.NonGeneric
+                    .Serialize(schematic.GetType(), schematic, ContractlessStandardResolver.Instance)
+            };
+        }
+
+        public async Task<GetMachineMetadataResponse> GetMachineMetadataAsync<TState, TInput>(
+            string machineId, 
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var machine = await engine.GetMachineAsync(machineId, cancellationToken).ConfigureAwait(false);
+
+            var metadata = await machine.GetMetadataAsync(cancellationToken).ConfigureAwait(false);
+
+            return new GetMachineMetadataResponse
+            {
+                MachineId = machine.MachineId,
+                Metadata = (IDictionary<string, string>)metadata
+            };
+        }
+
+        public async Task<CreateMachineResponse> CreateMachineFromStoreAsync<TState, TInput>(
+            string schematicName,
+            string machineId,
+            IDictionary<string, string> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var machine = await engine.CreateMachineAsync(
+                schematicName, 
+                machineId, 
+                metadata, 
+                cancellationToken);
+
+            return new CreateMachineResponse
+            {
+                MachineId = machine.MachineId
+            };
+        }
+
+        public async Task<CreateMachineResponse> CreateMachineFromSchematicAsync<TState, TInput>(
+            Schematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var machine = await engine.CreateMachineAsync(
+                schematic, 
+                machineId, 
+                metadata, 
+                cancellationToken);
+
+            return new CreateMachineResponse
+            {
+                MachineId = machine.MachineId
+            };
+        }
+
+        public async Task BulkCreateMachineFromStoreAsync<TState, TInput>(
+            string schematicName,
+            IEnumerable<IDictionary<string, string>> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            await engine.BulkCreateMachinesAsync(schematicName, metadata, cancellationToken);
+        }
+
+        public async Task BulkCreateMachineFromSchematicAsync<TState, TInput>(
+            Schematic<TState, TInput> schematic,
+            IEnumerable<IDictionary<string, string>> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            var engine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            await engine.BulkCreateMachinesAsync(schematic, metadata, cancellationToken);
+        }
+
+        public async Task<GetSchematicResponse> GetSchematicAsync<TState, TInput>(
+            string schematicName, 
+            CancellationToken cancellationToken)
+        {
+            var stateEngine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            var schematic = await stateEngine.GetSchematicAsync(
+                schematicName, 
+                cancellationToken).ConfigureAwait(false);
+
+            return new GetSchematicResponse
+            {
+                SchematicBytes = MessagePackSerializer.NonGeneric.Serialize(
+                    schematic.GetType(), 
+                    schematic, 
+                    ContractlessStandardResolver.Instance)
+            };
+        }
+
+        public async Task DeleteMachineAsync<TState, TInput>(
+            string machineId, 
+            CancellationToken cancellationToken)
+        {
+            var stateEngine = REstateHost.Agent
+                .AsLocal()
+                .GetStateEngine<TState, TInput>();
+
+            await stateEngine.DeleteMachineAsync(
+                machineId, 
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change
:bug: Move StateMachineService local Agent to a new interface

- Resolve an issue with unit test delegates being cached, which interfered with scenario tests
- Add IStateMachineServiceLocalAdapter and implementation which support clearer mocking and better focuses StateMachineService
- Remove regions from StateMachineService
- Make non-virtual internal methods private on StateMachineService
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in REstate as opposed to a community package -->

### Benefits
Eases mocking, testing, and clarity of StateMachineService
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Not the most intuitive mock setup ever
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#8 
<!-- Enter any applicable Issues here -->
