### PR TITLE
Add a BoundPorts property to REstate gRPC Server

### DIFF
--- a/src/REstate.Remote/REstateGrpcServer.cs
+++ b/src/REstate.Remote/REstateGrpcServer.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using MagicOnion.Server;
@@ -47,6 +50,8 @@ namespace REstate.Remote
 
         public Task ShutdownTask => Server.ShutdownTask;
 
+        public int[] BoundPorts { get; private set; }
+
         public Task StartAsync()
         {
             Server.Start();
@@ -58,11 +63,14 @@ namespace REstate.Remote
             try
             {
                 Server.Start();
+                Server.ShutdownTask.ContinueWith(task => BoundPorts = new int[0]);
             }
             catch (InvalidOperationException)
             {
                 // Swallow server already started exceptions
             }
+
+            BoundPorts = Server.Ports.Select(port => port.BoundPort).ToArray();
         }
 
         public Task ShutdownAsync()

--- a/test/REstate.Remote.Tests/Features/Context/REstateRemoteContext.cs
+++ b/test/REstate.Remote.Tests/Features/Context/REstateRemoteContext.cs
@@ -20,7 +20,7 @@ namespace REstate.Remote.Tests.Features.Context
     public class REstateRemoteContext<TState, TInput>
         : REstateContext<TState, TInput>
     {
-        public void Given_a_REstate_gRPC_Server_running()
+        public Task Given_a_REstate_gRPC_Server_running()
         {
             if (CurrentGrpcServer == null)
             {
@@ -36,9 +36,11 @@ namespace REstate.Remote.Tests.Features.Context
             }
 
             CurrentGrpcServer.Start();
+
+            return Task.CompletedTask;
         }
 
-        public void When_a_REstate_gRPC_Server_is_created_and_started()
+        public Task When_a_REstate_gRPC_Server_is_created_and_started()
         {
             if (CurrentGrpcServer == null)
             {
@@ -54,9 +56,11 @@ namespace REstate.Remote.Tests.Features.Context
             }
 
             CurrentGrpcServer.Start();
+
+            return Task.CompletedTask;
         }
 
-        public void Given_the_default_agent_is_gRPC_remote()
+        public Task Given_the_default_agent_is_gRPC_remote()
         {
             CurrentHost.Agent().Configuration
                 .RegisterComponent(new GrpcRemoteHostComponent(new GrpcHostOptions
@@ -64,18 +68,22 @@ namespace REstate.Remote.Tests.Features.Context
                     Channel = new Channel("localhost", CurrentGrpcServer.BoundPorts[0], ChannelCredentials.Insecure),
                     UseAsDefaultEngine = true
                 }));
+
+            return Task.CompletedTask;
         }
 
-        public void Then_REstate_gRPC_Server_has_bound_ports()
+        public Task Then_REstate_gRPC_Server_has_bound_ports()
         {
             Assert.NotNull(CurrentGrpcServer);
             Assert.NotEmpty(CurrentGrpcServer.BoundPorts);
             Assert.DoesNotContain(0, CurrentGrpcServer.BoundPorts);
+
+            return Task.CompletedTask;
         }
 
-        public void Given_a_REstate_gRPC_Server_failure()
+        public async Task Given_a_REstate_gRPC_Server_failure()
         {
-            CurrentGrpcServer.KillAsync().GetAwaiter().GetResult();
+            await CurrentGrpcServer.KillAsync();
         }
     }
 }

--- a/test/REstate.Remote.Tests/Features/GrpcServer.cs
+++ b/test/REstate.Remote.Tests/Features/GrpcServer.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios.Contextual;
+using LightBDD.Framework.Scenarios.Extended;
+using LightBDD.XUnit2;
+using REstate.Remote.Tests.Features.Context;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace REstate.Remote.Tests.Features
+{
+    [FeatureDescription(@"
+In order to support cloud scaling
+As a developer
+I want to connect using gRPC to a remote REstate server")]
+    [ScenarioCategory("REstate gRPC Server")]
+    [ScenarioCategory("Remote")]
+    [ScenarioCategory("gRPC")]
+    [Collection("gRPC")]
+    public class GrpcServer
+        : FeatureFixture
+    {
+        [Scenario]
+        public void REstate_gRPC_Server_Sets_BoundPorts_on_start()
+        {
+            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+                _ => _.Given_a_new_host(),
+                _ => _.When_a_REstate_gRPC_Server_is_created_and_started(),
+                _ => _.Then_REstate_gRPC_Server_has_bound_ports());
+        }
+
+        #region Constructor
+        public GrpcServer(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+        #endregion
+    }
+}

--- a/test/REstate.Remote.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Remote.Tests/Features/MachineCreation.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
@@ -22,11 +23,13 @@ I want to create Machines from Schematics on a remote server")]
         : FeatureFixture
     {
         [Scenario]
-        public void A_Machine_can_be_created_from_a_Schematic()
+        public async Task A_Machine_can_be_created_from_a_Schematic()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic);
 
-            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+
+            await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_REstate_gRPC_Server_running(),
                 _ => _.Given_the_default_agent_is_gRPC_remote(),
@@ -37,11 +40,13 @@ I want to create Machines from Schematics on a remote server")]
         }
 
         [Scenario]
-        public void A_Machine_can_be_created_from_a_SchematicName()
+        public async Task A_Machine_can_be_created_from_a_SchematicName()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName);
 
-            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+
+            await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_REstate_gRPC_Server_running(),
                 _ => _.Given_the_default_agent_is_gRPC_remote(),
@@ -53,12 +58,14 @@ I want to create Machines from Schematics on a remote server")]
         }
 
         [Scenario]
-        public void A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
+        public async Task A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
-            var machineId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId);
 
-            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+            const string machineId = uniqueId;
+
+            await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_REstate_gRPC_Server_running(),
                 _ => _.Given_the_default_agent_is_gRPC_remote(),
@@ -70,12 +77,14 @@ I want to create Machines from Schematics on a remote server")]
         }
 
         [Scenario]
-        public void A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
+        public async Task A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
-            var machineId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId);
 
-            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+            const string machineId = uniqueId;
+
+            await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_REstate_gRPC_Server_running(),
                 _ => _.Given_the_default_agent_is_gRPC_remote(),

--- a/test/REstate.Remote.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Remote.Tests/Features/MachineCreation.cs
@@ -18,7 +18,6 @@ I want to create Machines from Schematics on a remote server")]
     [ScenarioCategory("Machine Creation")]
     [ScenarioCategory("Remote")]
     [ScenarioCategory("gRPC")]
-    [Collection("gRPC")]
     public class MachineCreation
         : FeatureFixture
     {
@@ -29,8 +28,8 @@ I want to create Machines from Schematics on a remote server")]
 
             Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
-                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_REstate_gRPC_Server_running(),
+                _ => _.Given_the_default_agent_is_gRPC_remote(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.When_a_Machine_is_created_from_a_Schematic(_.CurrentSchematic),
                 _ => _.Then_no_exception_was_thrown(),
@@ -44,8 +43,8 @@ I want to create Machines from Schematics on a remote server")]
 
             Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
-                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_REstate_gRPC_Server_running(),
+                _ => _.Given_the_default_agent_is_gRPC_remote(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
                 _ => _.When_a_Machine_is_created_from_a_SchematicName(_.CurrentSchematic.SchematicName),
@@ -61,8 +60,8 @@ I want to create Machines from Schematics on a remote server")]
 
             Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
-                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_REstate_gRPC_Server_running(),
+                _ => _.Given_the_default_agent_is_gRPC_remote(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(_.CurrentSchematic, machineId),
                 _ => _.Then_no_exception_was_thrown(),
@@ -78,8 +77,8 @@ I want to create Machines from Schematics on a remote server")]
 
             Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
-                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_REstate_gRPC_Server_running(),
+                _ => _.Given_the_default_agent_is_gRPC_remote(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
                 _ => _.When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(_.CurrentSchematic.SchematicName, machineId),

--- a/test/REstate.Remote.Tests/Features/MachineRetrieval.cs
+++ b/test/REstate.Remote.Tests/Features/MachineRetrieval.cs
@@ -20,7 +20,6 @@ I want to retrieve Machines from a remote server")]
     [ScenarioCategory("Machine Retrieval")]
     [ScenarioCategory("Remote")]
     [ScenarioCategory("gRPC")]
-    [Collection("gRPC")]
     public class MachineRetrieval
         : FeatureFixture
     {
@@ -34,8 +33,8 @@ I want to retrieve Machines from a remote server")]
 
             Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
-                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_REstate_gRPC_Server_running(),
+                _ => _.Given_the_default_agent_is_gRPC_remote(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.Given_a_Machine_exists_with_MachineId_MACHINEID(_.CurrentSchematic, machineId),
                 _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
@@ -52,8 +51,8 @@ I want to retrieve Machines from a remote server")]
 
             Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
                 _ => _.Given_a_new_host(),
-                _ => _.Given_a_REstate_gRPC_Server_running_on_the_default_endpoint(),
-                _ => _.Given_the_default_agent_is_gRPC_remote_on_default_endpoint(),
+                _ => _.Given_a_REstate_gRPC_Server_running(),
+                _ => _.Given_the_default_agent_is_gRPC_remote(),
                 _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
                 _ => _.Then_MachineDoesNotExistException_is_thrown());
         }

--- a/test/REstate.Remote.Tests/Features/MachineRetrieval.cs
+++ b/test/REstate.Remote.Tests/Features/MachineRetrieval.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
@@ -24,14 +25,14 @@ I want to retrieve Machines from a remote server")]
         : FeatureFixture
     {
         [Scenario]
-        public void A_Machine_can_be_retrieved()
+        public async Task A_Machine_can_be_retrieved()
         {
-            var uniqueId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_retrieved);
 
-            var schematicName = uniqueId;
-            var machineId = uniqueId;
+            const string schematicName = uniqueId;
+            const string machineId = uniqueId;
 
-            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+            await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_REstate_gRPC_Server_running(),
                 _ => _.Given_the_default_agent_is_gRPC_remote(),
@@ -43,13 +44,13 @@ I want to retrieve Machines from a remote server")]
         }
 
         [Scenario]
-        public void A_NonExistant_Machine_cannot_be_retrieved()
+        public async Task A_NonExistant_Machine_cannot_be_retrieved()
         {
-            var uniqueId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_NonExistant_Machine_cannot_be_retrieved);
 
-            var machineId = uniqueId;
+            const string machineId = uniqueId;
 
-            Runner.WithContext<REstateRemoteContext<string, string>>().RunScenario(
+            await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_REstate_gRPC_Server_running(),
                 _ => _.Given_the_default_agent_is_gRPC_remote(),

--- a/test/REstate.Tests/Features/Configuration.cs
+++ b/test/REstate.Tests/Features/Configuration.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
@@ -19,9 +20,9 @@ I want to use the configuration")]
         : FeatureFixture
     {
         [Scenario]
-        public void Configuration_is_accessible_with_default_container()
+        public async Task Configuration_is_accessible_with_default_container()
         {
-            Runner.WithContext<REstateContext>().RunScenario(
+            await Runner.WithContext<REstateContext>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.When_configuration_is_accessed(),
                 _ => _.Then_no_exception_was_thrown(),
@@ -30,11 +31,11 @@ I want to use the configuration")]
         }
 
         [Scenario]
-        public void Configuration_is_accessible_with_custom_container()
+        public async Task Configuration_is_accessible_with_custom_container()
         {
             var customComponentContainer = new BoDiComponentContainer(new ObjectContainer());
 
-            Runner.WithContext<REstateContext>().RunScenario(
+            await Runner.WithContext<REstateContext>().RunScenarioAsync(
                 _ => _.Given_a_new_host_with_custom_ComponentContainer(customComponentContainer),
                 _ => _.When_configuration_is_accessed(),
                 _ => _.Then_no_exception_was_thrown(),

--- a/test/REstate.Tests/Features/Context/Configuration.cs
+++ b/test/REstate.Tests/Features/Context/Configuration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace REstate.Tests.Features.Context
@@ -7,7 +8,7 @@ namespace REstate.Tests.Features.Context
     {
         public IHostConfiguration CurrentHostConfiguration { get; set; }
 
-        public void When_configuration_is_accessed()
+        public Task When_configuration_is_accessed()
         {
             try
             {
@@ -17,16 +18,22 @@ namespace REstate.Tests.Features.Context
             {
                 CurrentException = ex;
             }
+
+            return Task.CompletedTask;
         }
 
-        public void Then_configuration_has_a_container()
+        public Task Then_configuration_has_a_container()
         {
             Assert.NotNull(((HostConfiguration)CurrentHostConfiguration).Container);
+
+            return Task.CompletedTask;
         }
 
-        public void Then_configuration_is_not_null()
+        public Task Then_configuration_is_not_null()
         {
             Assert.NotNull(CurrentHostConfiguration);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/REstate.Tests/Features/Context/Host.cs
+++ b/test/REstate.Tests/Features/Context/Host.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using REstate.IoC;
 using Xunit;
 
@@ -10,19 +11,25 @@ namespace REstate.Tests.Features.Context
 
         public Exception CurrentException { get; set; }
 
-        public void Given_a_new_host()
+        public Task Given_a_new_host()
         {
             CurrentHost = new REstateHost();
+
+            return Task.CompletedTask;
         }
 
-        public void Given_a_new_host_with_custom_ComponentContainer(IComponentContainer componentContainer)
+        public Task Given_a_new_host_with_custom_ComponentContainer(IComponentContainer componentContainer)
         {
             CurrentHost = new REstateHost(componentContainer);
+
+            return Task.CompletedTask;
         }
 
-        public void Then_no_exception_was_thrown()
+        public Task Then_no_exception_was_thrown()
         {
             Assert.Null(CurrentException);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/REstate.Tests/Features/Context/Machines.cs
+++ b/test/REstate.Tests/Features/Context/Machines.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using REstate.Engine;
 using REstate.Schematics;
 using Xunit;
@@ -9,27 +10,27 @@ namespace REstate.Tests.Features.Context
     {
         public IStateMachine<TState, TInput> CurrentMachine { get; set; }
 
-        public void When_a_Machine_is_created_from_a_Schematic(Schematic<TState, TInput> schematic)
-        {
-            try
-            { 
-            CurrentMachine = CurrentHost.Agent()
-                .GetStateEngine<TState, TInput>()
-                .CreateMachineAsync(schematic).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                CurrentException = ex;
-            }
-        }
-
-        public void When_a_Machine_is_created_from_a_SchematicName(string schematicName)
+        public async Task When_a_Machine_is_created_from_a_Schematic(Schematic<TState, TInput> schematic)
         {
             try
             {
-                CurrentMachine = CurrentHost.Agent()
+                CurrentMachine = await CurrentHost.Agent()
                     .GetStateEngine<TState, TInput>()
-                    .CreateMachineAsync(schematicName).GetAwaiter().GetResult();
+                    .CreateMachineAsync(schematic);
+            }
+            catch (Exception ex)
+            {
+                CurrentException = ex;
+            }
+        }
+
+        public async Task When_a_Machine_is_created_from_a_SchematicName(string schematicName)
+        {
+            try
+            {
+                CurrentMachine = await CurrentHost.Agent()
+                    .GetStateEngine<TState, TInput>()
+                    .CreateMachineAsync(schematicName);
             }
             catch (Exception ex)
             {
@@ -38,14 +39,14 @@ namespace REstate.Tests.Features.Context
 
         }
 
-        public void When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(
+        public async Task When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(
             Schematic<TState, TInput> schematic, string machineId)
         {
             try
             {
-                CurrentMachine = CurrentHost.Agent()
+                CurrentMachine = await CurrentHost.Agent()
                     .GetStateEngine<TState, TInput>()
-                    .CreateMachineAsync(schematic, machineId).GetAwaiter().GetResult();
+                    .CreateMachineAsync(schematic, machineId);
             }
             catch (Exception ex)
             {
@@ -53,14 +54,14 @@ namespace REstate.Tests.Features.Context
             }
         }
 
-        public void When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(
+        public async Task When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(
             string schematicName, string machineId)
         {
             try
             {
-                CurrentMachine = CurrentHost.Agent()
+                CurrentMachine = await CurrentHost.Agent()
                     .GetStateEngine<TState, TInput>()
-                    .CreateMachineAsync(schematicName, machineId).GetAwaiter().GetResult();
+                    .CreateMachineAsync(schematicName, machineId);
             }
             catch (Exception ex)
             {
@@ -68,32 +69,37 @@ namespace REstate.Tests.Features.Context
             }
         }
 
-        public void Then_the_Machine_is_valid(IStateMachine<TState, TInput> machine)
+        public Task Then_the_Machine_is_valid(IStateMachine<TState, TInput> machine)
         {
             Assert.NotNull(machine);
             Assert.NotNull(machine.MachineId);
             Assert.NotEmpty(machine.MachineId);
+
+            return Task.CompletedTask;
         }
 
-        public void Then_the_MachineId_is_MACHINEID(IStateMachine<TState, TInput> machine, string machineId)
+        public Task Then_the_MachineId_is_MACHINEID(IStateMachine<TState, TInput> machine, string machineId)
         {
             Assert.Equal(machineId, CurrentMachine.MachineId);
+
+            return Task.CompletedTask;
         }
 
-        public void Given_a_Machine_exists_with_MachineId_MACHINEID(Schematic<TState, TInput> schematic, string machineId)
+        public async Task Given_a_Machine_exists_with_MachineId_MACHINEID(Schematic<TState, TInput> schematic, string machineId)
         {
-            CurrentHost.Agent()
+            CurrentMachine = await CurrentHost.Agent()
                 .GetStateEngine<TState, TInput>()
-                .CreateMachineAsync(schematic, machineId).GetAwaiter().GetResult();
+                .CreateMachineAsync(schematic, machineId);
         }
 
-        public void When_a_Machine_is_retrieved_with_MachineId_MACHINEID(string machineId)
+        public async Task When_a_Machine_is_retrieved_with_MachineId_MACHINEID(string machineId)
         {
             try
             {
-                CurrentMachine = CurrentHost.Agent()
+                CurrentMachine = null;
+                CurrentMachine = await CurrentHost.Agent()
                     .GetStateEngine<TState, TInput>()
-                    .GetMachineAsync(machineId).GetAwaiter().GetResult();
+                    .GetMachineAsync(machineId);
             }
             catch (Exception ex)
             {
@@ -101,10 +107,12 @@ namespace REstate.Tests.Features.Context
             }
         }
 
-        public void Then_MachineDoesNotExistException_is_thrown()
+        public Task Then_MachineDoesNotExistException_is_thrown()
         {
             Assert.NotNull(CurrentException);
             Assert.IsType<MachineDoesNotExistException>(CurrentException);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/REstate.Tests/Features/Context/Schematics.cs
+++ b/test/REstate.Tests/Features/Context/Schematics.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using REstate.Schematics;
 
 namespace REstate.Tests.Features.Context
@@ -8,20 +9,22 @@ namespace REstate.Tests.Features.Context
     {
         public Schematic<TState, TInput> CurrentSchematic { get; set; }
 
-        public void Given_a_Schematic_with_an_initial_state_INITIALSTATE(string schematicName, TState initialState)
+        public Task Given_a_Schematic_with_an_initial_state_INITIALSTATE(string schematicName, TState initialState)
         {
             CurrentSchematic = CurrentHost.Agent()
                 .CreateSchematic<TState, TInput>(schematicName)
                 .WithState(initialState, state => state
                     .AsInitialState())
                 .Build();
+
+            return Task.CompletedTask;
         }
 
-        public void Given_a_Schematic_is_stored(Schematic<TState, TInput> schematic)
+        public async Task Given_a_Schematic_is_stored(Schematic<TState, TInput> schematic)
         {
-            CurrentHost.Agent()
+            await CurrentHost.Agent()
                 .GetStateEngine<TState, TInput>()
-                .StoreSchematicAsync(schematic).GetAwaiter().GetResult();
+                .StoreSchematicAsync(schematic);
         }
     }
 }

--- a/test/REstate.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Tests/Features/MachineCreation.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
@@ -19,11 +20,13 @@ I want to create machines from schematics")]
         : FeatureFixture
     {
         [Scenario]
-        public void A_Machine_can_be_created_from_a_Schematic()
+        public async Task A_Machine_can_be_created_from_a_Schematic()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic);
 
-            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+
+            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.When_a_Machine_is_created_from_a_Schematic(_.CurrentSchematic),
@@ -32,11 +35,13 @@ I want to create machines from schematics")]
         }
 
         [Scenario]
-        public void A_Machine_can_be_created_from_a_SchematicName()
+        public async Task A_Machine_can_be_created_from_a_SchematicName()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName);
 
-            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+
+            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
@@ -46,12 +51,14 @@ I want to create machines from schematics")]
         }
 
         [Scenario]
-        public void A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
+        public async Task A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
-            var machineId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId);
 
-            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+            const string machineId = uniqueId;
+
+            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(_.CurrentSchematic, machineId),
@@ -61,12 +68,14 @@ I want to create machines from schematics")]
         }
 
         [Scenario]
-        public void A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
+        public async Task A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
         {
-            var schematicName = MethodBase.GetCurrentMethod().Name;
-            var machineId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId);
 
-            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+            const string schematicName = uniqueId;
+            const string machineId = uniqueId;
+
+            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),

--- a/test/REstate.Tests/Features/MachineRetrieval.cs
+++ b/test/REstate.Tests/Features/MachineRetrieval.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
@@ -21,14 +22,14 @@ I want to retrieve previously created machines")]
         : FeatureFixture
     {
         [Scenario]
-        public void A_Machine_can_be_retrieved()
+        public async Task A_Machine_can_be_retrieved()
         {
-            var uniqueId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_Machine_can_be_retrieved);
 
-            var schematicName = uniqueId;
-            var machineId = uniqueId;
+            const string schematicName = uniqueId;
+            const string machineId = uniqueId;
 
-            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
                 _ => _.Given_a_Machine_exists_with_MachineId_MACHINEID(_.CurrentSchematic, machineId),
@@ -38,13 +39,13 @@ I want to retrieve previously created machines")]
         }
 
         [Scenario]
-        public void A_NonExistant_Machine_cannot_be_retrieved()
+        public async Task A_NonExistant_Machine_cannot_be_retrieved()
         {
-            var uniqueId = MethodBase.GetCurrentMethod().Name;
+            const string uniqueId = nameof(A_NonExistant_Machine_cannot_be_retrieved);
 
-            var machineId = uniqueId;
+            const string machineId = uniqueId;
 
-            Runner.WithContext<REstateContext<string, string>>().RunScenario(
+            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
                 _ => _.Then_MachineDoesNotExistException_is_thrown());


### PR DESCRIPTION
### Description of the Change
✨ Adds a BoundPorts property to the gRPC server, so that a user can discover the bound ports when using the `0` flag for allocating a server on any unused port.

💚 Also had to convert scenario tests to `async` due to deadlocks under weird thread unavailability scenarios.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?
The flexibility is really nice for ad-hoc scenarios and tests.
<!-- Explain why this functionality should be in REstate as opposed to a community package -->

### Benefits
Using `0` for port allows you to run multiple isolated REstate servers on a single machine. Can be load balanced at another layer if desired.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
