### PR TITLE
Add retry on state conflicts

### DIFF
--- a/src/REstate.Engine.Repositories.Redis/REstate.Engine.Repositories.Redis.csproj
+++ b/src/REstate.Engine.Repositories.Redis/REstate.Engine.Repositories.Redis.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>REstate</PackageTags>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/REstate.Remote/REstate.Remote.csproj
+++ b/src/REstate.Remote/REstate.Remote.csproj
@@ -15,7 +15,7 @@
     <Description>Provides gRPC/HTTP2 interconnect support for REstate's engine in either client or server configuration.</Description>
     <Copyright>Ovan Crone 2016</Copyright>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/REstate/Engine/StateConflictException.cs
+++ b/src/REstate/Engine/StateConflictException.cs
@@ -8,8 +8,10 @@ namespace REstate.Engine
     public class StateConflictException
         : Exception
     {
+        private const string StandardMessage = "CommitTag did not match; no update performed.";
+
         public StateConflictException()
-            : this("CommitTag did not match; no update performed.")
+            : this(StandardMessage)
         {
         }
 
@@ -21,6 +23,12 @@ namespace REstate.Engine
         public StateConflictException(string message, Exception innerException) 
             : base(message, innerException)
         {
+        }
+
+        public StateConflictException(Exception innerException)
+            : this(StandardMessage, innerException)
+        {
+
         }
     }
 }

--- a/src/REstate/REstate.csproj
+++ b/src/REstate/REstate.csproj
@@ -10,7 +10,7 @@
     <Version>3.0.0</Version>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>latest</LangVersion>
     <PackageProjectUrl>https://github.com/psibr/REstate.Engine</PackageProjectUrl>
     <RepositoryUrl>https://github.com/psibr/REstate.Engine</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/REstate/REstateHost.cs
+++ b/src/REstate/REstateHost.cs
@@ -26,21 +26,19 @@ namespace REstate
 
         public REstateHost()
         {
-            ((IHasAgentLazy) this).AgentLazy = new Lazy<IAgent>(CreateAgent);
+            ((IHasAgentLazy)this).AgentLazy = new Lazy<IAgent>(CreateAgent);
         }
 
-        private static REstateHost SharedInstance => new REstateHost();
+        internal static readonly REstateHost SharedInstance = new REstateHost();
 
         internal readonly object ConfigurationSyncRoot = new object();
 
         private IAgent CreateAgent()
         {
-            lock (ConfigurationSyncRoot)
-            {
-                TryUseContainer(this, new BoDiComponentContainer(new ObjectContainer()));
+            TryUseContainer(this, new BoDiComponentContainer(new ObjectContainer()));
 
-                return new Agent(HostConfiguration);
-            }
+            return new Agent(HostConfiguration);
+
         }
 
         Lazy<IAgent> IHasAgentLazy.AgentLazy { get; set; }
@@ -56,7 +54,7 @@ namespace REstate
         /// <param name="container">The container to use.</param>
         public static void UseContainer(IComponentContainer container)
         {
-            if(!TryUseContainer(SharedInstance, container))
+            if (!TryUseContainer(SharedInstance, container))
                 throw new InvalidOperationException(
                     "Configuration has already been initialized; " +
                     "cannot replace container at this point.");

--- a/src/REstate/Schematics/Builder/ISchematicBuilder.cs
+++ b/src/REstate/Schematics/Builder/ISchematicBuilder.cs
@@ -6,6 +6,8 @@ namespace REstate.Schematics.Builder
     public interface ISchematicBuilder<TState, TInput>
         : ISchematic<TState, TInput>
     {
+        ISchematicBuilder<TState, TInput> WithStateConflictRetries();
+        ISchematicBuilder<TState, TInput> WithStateConflictRetries(int retryCount);
         ISchematicBuilder<TState, TInput> WithState(TState state, Action<IStateBuilder<TState, TInput>> stateBuilderAction = null);
         ISchematicBuilder<TState, TInput> WithStates(ICollection<TState> states, Action<IStateBuilder<TState, TInput>> stateBuilderAction = null);
         ISchematicBuilder<TState, TInput> WithStates(params TState[] states);

--- a/src/REstate/Schematics/Builder/Implementation/SchematicBuilder.cs
+++ b/src/REstate/Schematics/Builder/Implementation/SchematicBuilder.cs
@@ -23,6 +23,8 @@ namespace REstate.Schematics.Builder.Implementation
 
         public TState InitialState { get; private set; }
 
+        public int StateConflictRetryCount { get; private set; }
+
         internal void SetInitialState(TState state)  
         {
             InitialState = state;
@@ -90,7 +92,7 @@ namespace REstate.Schematics.Builder.Implementation
             if (!_stateConfigurations.ContainsKey(resultantState))
                 throw new ArgumentException("Resultant stateBuilderAction was not defined.", nameof(resultantState));
 
-            if (_stateConfigurations.TryGetValue(sourceState, out IStateBuilder<TState, TInput> stateBuilder))
+            if (_stateConfigurations.TryGetValue(sourceState, out var stateBuilder))
             {
                 try
                 {
@@ -122,11 +124,27 @@ namespace REstate.Schematics.Builder.Implementation
 
             return new Schematic<TState, TInput>(
                 schematic.SchematicName, 
-                schematic.InitialState, 
+                schematic.InitialState,
+                schematic.StateConflictRetryCount,
                 schematic.States.Values
                     .Select(SchematicCloner.Clone)
                     .ToArray());
             
+        }
+
+        public ISchematicBuilder<TState, TInput> WithStateConflictRetries()
+        {
+            return WithStateConflictRetries(-1);
+        }
+
+        public ISchematicBuilder<TState, TInput> WithStateConflictRetries(int retryCount)
+        {
+            if(retryCount < -1)
+                throw new ArgumentException("Values below -1 are not valid.", nameof(retryCount));
+
+            StateConflictRetryCount = retryCount;
+
+            return this;
         }
     }
 }

--- a/src/REstate/Schematics/ISchematic.cs
+++ b/src/REstate/Schematics/ISchematic.cs
@@ -6,6 +6,7 @@ namespace REstate.Schematics
     {
         string SchematicName { get; }
         TState InitialState { get; }
+        int StateConflictRetryCount { get; }
         IReadOnlyDictionary<TState, IState<TState, TInput>> States { get; }
     }
 }

--- a/src/REstate/Schematics/Schematic.cs
+++ b/src/REstate/Schematics/Schematic.cs
@@ -9,10 +9,11 @@ namespace REstate.Schematics
     public class Schematic<TState, TInput> 
         : ISchematic<TState, TInput>
     {
-        public Schematic(string schematicName, TState initialState, State<TState, TInput>[] states)
+        public Schematic(string schematicName, TState initialState, int stateConflictRetryCount, params State<TState, TInput>[] states)
         {
             SchematicName = schematicName;
             InitialState = initialState;
+            StateConflictRetryCount = stateConflictRetryCount;
             States = states;
         }
 
@@ -25,6 +26,8 @@ namespace REstate.Schematics
 
         [Required]
         public TState InitialState { get; set; }
+
+        public int StateConflictRetryCount { get; set; }
 
         IReadOnlyDictionary<TState, IState<TState, TInput>> ISchematic<TState, TInput>.States => 
             States.ToDictionary(

--- a/src/REstate/Schematics/SchematicCloner.cs
+++ b/src/REstate/Schematics/SchematicCloner.cs
@@ -9,6 +9,7 @@ namespace REstate.Schematics
             new Schematic<TState, TInput>(
                 schematic.SchematicName,
                 schematic.InitialState,
+                schematic.StateConflictRetryCount,
                 schematic.States.Values
                     .Select(Clone)
                     .ToArray());

--- a/test/REstate.Remote.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Remote.Tests/Features/MachineCreation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using LightBDD.Framework;
@@ -25,9 +26,9 @@ I want to create Machines from Schematics on a remote server")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_Schematic()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
+            var schematicName = uniqueId;
 
             await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -42,9 +43,9 @@ I want to create Machines from Schematics on a remote server")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_SchematicName()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
+            var schematicName = uniqueId;
 
             await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -60,10 +61,10 @@ I want to create Machines from Schematics on a remote server")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
-            const string machineId = uniqueId;
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -79,10 +80,10 @@ I want to create Machines from Schematics on a remote server")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
-            const string machineId = uniqueId;
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),

--- a/test/REstate.Remote.Tests/Features/MachineRetrieval.cs
+++ b/test/REstate.Remote.Tests/Features/MachineRetrieval.cs
@@ -27,10 +27,10 @@ I want to retrieve Machines from a remote server")]
         [Scenario]
         public async Task A_Machine_can_be_retrieved()
         {
-            const string uniqueId = nameof(A_Machine_can_be_retrieved);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
-            const string machineId = uniqueId;
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -46,9 +46,9 @@ I want to retrieve Machines from a remote server")]
         [Scenario]
         public async Task A_NonExistant_Machine_cannot_be_retrieved()
         {
-            const string uniqueId = nameof(A_NonExistant_Machine_cannot_be_retrieved);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string machineId = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),

--- a/test/REstate.Remote.Tests/REstate.Remote.Tests.csproj
+++ b/test/REstate.Remote.Tests/REstate.Remote.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/REstate.Tests/Features/Context/Machines.cs
+++ b/test/REstate.Tests/Features/Context/Machines.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using REstate.Engine;
 using REstate.Schematics;
 using Xunit;
+using Xunit.Sdk;
 
 namespace REstate.Tests.Features.Context
 {

--- a/test/REstate.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Tests/Features/MachineCreation.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
@@ -22,9 +23,9 @@ I want to create machines from schematics")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_Schematic()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
+            var schematicName = uniqueId;
 
             await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -37,9 +38,9 @@ I want to create machines from schematics")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_SchematicName()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
+            var schematicName = uniqueId;
 
             await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -53,10 +54,10 @@ I want to create machines from schematics")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
-            const string machineId = uniqueId;
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -70,10 +71,10 @@ I want to create machines from schematics")]
         [Scenario]
         public async Task A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
         {
-            const string uniqueId = nameof(A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
-            const string machineId = uniqueId;
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),

--- a/test/REstate.Tests/Features/MachineRetrieval.cs
+++ b/test/REstate.Tests/Features/MachineRetrieval.cs
@@ -24,10 +24,10 @@ I want to retrieve previously created machines")]
         [Scenario]
         public async Task A_Machine_can_be_retrieved()
         {
-            const string uniqueId = nameof(A_Machine_can_be_retrieved);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string schematicName = uniqueId;
-            const string machineId = uniqueId;
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),
@@ -41,9 +41,9 @@ I want to retrieve previously created machines")]
         [Scenario]
         public async Task A_NonExistant_Machine_cannot_be_retrieved()
         {
-            const string uniqueId = nameof(A_NonExistant_Machine_cannot_be_retrieved);
+            var uniqueId = Guid.NewGuid().ToString();
 
-            const string machineId = uniqueId;
+            var machineId = uniqueId;
 
             await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
                 _ => _.Given_a_new_host(),

--- a/test/REstate.Tests/REstate.Tests.csproj
+++ b/test/REstate.Tests/REstate.Tests.csproj
@@ -6,6 +6,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="LightBDD.XUnit2" Version="2.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
@@ -17,12 +25,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\REstate\REstate.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="My_feature1.Steps.cs">
-      <SubType>Code</SubType>
-    </Compile>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!--
Requirements
* All new code requires tests to ensure against regressions
-->

Add retry logic on state conflict, and a configurable parameter in the schematic.

Had to update tests to resolve some concurrency issues by changing keys used in the in memory db.

<!-- Uncomment the following sections as needed -->

<!-- Explain what other alternates were considered and why the proposed version was selected
### Alternate Designs
-->

<!-- Explain why this functionality should be in REstate as opposed to a community package 
### Why Should This Be In Core?

-->

<!-- What benefits will be realized by the code change? 
### Benefits
-->

<!-- What are the possible side-effects or negative impacts of the code change?
### Possible Drawbacks
 -->

### Applicable Issues

<!-- Enter any applicable issue numbers here -->
