### PR TITLE
Add EntityFramework Core support

### DIFF
--- a/REstate.sln
+++ b/REstate.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2003
+VisualStudioVersion = 15.0.27130.2020
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "REstate", "src\REstate\REstate.csproj", "{8B02FF53-A9F3-4004-8CDC-32831070957D}"
 EndProject
@@ -28,6 +28,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "REstate.Remote.Tests", "test\REstate.Remote.Tests\REstate.Remote.Tests.csproj", "{C64BFCFB-3BF8-4662-A274-7ACC324232CD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Semaphore", "src\Examples\Semaphore\Semaphore.csproj", "{F15E390F-EFCF-4848-96C8-597BD75B7F9C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "REstate.Engine.Repositories.EntityFrameworkCore", "src\REstate.Engine.Repositories.EntityFrameworkCore\REstate.Engine.Repositories.EntityFrameworkCore.csproj", "{3E0263FE-540E-401E-818A-CB51350D30C2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "REstate.Engine.Repositories.EntityFrameworkCore.Tests", "test\REstate.Engine.Repositories.EntityFrameworkCore.Tests\REstate.Engine.Repositories.EntityFrameworkCore.Tests.csproj", "{5F424F7B-4840-414D-9FA3-7700D81AD898}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +75,14 @@ Global
 		{F15E390F-EFCF-4848-96C8-597BD75B7F9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F15E390F-EFCF-4848-96C8-597BD75B7F9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F15E390F-EFCF-4848-96C8-597BD75B7F9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E0263FE-540E-401E-818A-CB51350D30C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E0263FE-540E-401E-818A-CB51350D30C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E0263FE-540E-401E-818A-CB51350D30C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E0263FE-540E-401E-818A-CB51350D30C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F424F7B-4840-414D-9FA3-7700D81AD898}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F424F7B-4840-414D-9FA3-7700D81AD898}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F424F7B-4840-414D-9FA3-7700D81AD898}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F424F7B-4840-414D-9FA3-7700D81AD898}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,6 +98,8 @@ Global
 		{7E243087-D506-4D89-BB66-83C6DE063778} = {88B4B54C-3DA1-40D2-8DCB-0181DD035955}
 		{C64BFCFB-3BF8-4662-A274-7ACC324232CD} = {88B4B54C-3DA1-40D2-8DCB-0181DD035955}
 		{F15E390F-EFCF-4848-96C8-597BD75B7F9C} = {20BCC0A3-8FEB-4EFF-A175-22D1E3E4E233}
+		{3E0263FE-540E-401E-818A-CB51350D30C2} = {90E8D167-048D-467B-81D5-1007247226A3}
+		{5F424F7B-4840-414D-9FA3-7700D81AD898} = {88B4B54C-3DA1-40D2-8DCB-0181DD035955}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0C35B35D-40C1-4521-BF0A-C5A6D7BFF4CD}

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/EntityFrameworkCoreEngineRepositoryContext.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/EntityFrameworkCoreEngineRepositoryContext.cs
@@ -1,0 +1,403 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MessagePack;
+using MessagePack.Resolvers;
+using Microsoft.EntityFrameworkCore;
+using REstate.Schematics;
+
+namespace REstate.Engine.Repositories.EntityFrameworkCore
+{
+    public class EntityFrameworkCoreEngineRepositoryContext<TState, TInput>
+        : IEngineRepositoryContext<TState, TInput>
+        , ISchematicRepository<TState, TInput>
+        , IMachineRepository<TState, TInput>
+    {
+        public EntityFrameworkCoreEngineRepositoryContext(REstateDbContext dbContext)
+        {
+            DbContext = dbContext;
+        }
+
+
+        public ISchematicRepository<TState, TInput> Schematics => this;
+        public IMachineRepository<TState, TInput> Machines => this;
+
+        protected REstateDbContext DbContext { get; }
+
+        /// <summary>
+        /// Retrieves a previously stored Schematic by name.
+        /// </summary>
+        /// <param name="schematicName">The name of the Schematic</param>
+        /// <param name="cancellationToken"></param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="schematicName"/> is null.</exception>
+        /// <exception cref="SchematicDoesNotExistException">Thrown when no matching Schematic was found for the given name.</exception>
+        public async Task<Schematic<TState, TInput>> RetrieveSchematicAsync(string schematicName, CancellationToken cancellationToken = default)
+        {
+            if (schematicName == null) throw new ArgumentNullException(nameof(schematicName));
+
+            EntityFrameworkCoreSchematic result;
+            try
+            {
+                result = await DbContext.Schematics.SingleAsync(
+                    schematicRecord => schematicRecord.SchematicName == schematicName,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                throw new SchematicDoesNotExistException(schematicName);
+            }
+
+            var schematic = MessagePackSerializer.Deserialize<Schematic<TState, TInput>>(
+                           bytes: MessagePackSerializer.FromJson(result.SchematicJson), 
+                           resolver: ContractlessStandardResolver.Instance);
+
+            return schematic;
+        }
+
+        /// <summary>
+        /// Stores a Schematic, using its <c>SchematicName</c> as the key.
+        /// </summary>
+        /// <param name="schematic">The Schematic to store</param>
+        /// <param name="cancellationToken"></param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="schematic"/> is null.</exception>
+        /// <exception cref="System.ArgumentException">Thrown if <paramref name="schematic"/> has a null <c>SchematicName</c> property.</exception>
+        public async Task<Schematic<TState, TInput>> StoreSchematicAsync(Schematic<TState, TInput> schematic, CancellationToken cancellationToken = default)
+        {
+            if (schematic == null) throw new ArgumentNullException(nameof(schematic));
+            if (schematic.SchematicName == null) throw new ArgumentException("Schematic must have a name to be stored.", nameof(schematic));
+
+
+            var schematicJson = MessagePackSerializer.ToJson(
+                obj: schematic, 
+                resolver: ContractlessStandardResolver.Instance);
+
+            var record = new EntityFrameworkCoreSchematic
+            {
+                SchematicName = schematic.SchematicName,
+                SchematicJson = schematicJson
+            };
+
+            DbContext.Schematics.Add(record);
+
+            await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            return schematic;
+        }
+
+        /// <summary>
+        /// Creates a new Machine from a provided Schematic.
+        /// </summary>
+        /// <param name="schematicName">The name of the stored Schematic</param>
+        /// <param name="machineId">The Id of Machine to create; if null, an Id will be generated.</param>
+        /// <param name="metadata">Related metadata for the Machine</param>
+        /// <param name="cancellationToken"></param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="schematicName"/> is null.</exception>
+        public async Task<MachineStatus<TState, TInput>> CreateMachineAsync(string schematicName, string machineId, IDictionary<string, string> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            if (schematicName == null) throw new ArgumentNullException(nameof(schematicName));
+
+            var schematic = await RetrieveSchematicAsync(schematicName, cancellationToken).ConfigureAwait(false);
+
+            return await CreateMachineAsync(schematic, machineId, metadata, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new Machine from a provided Schematic.
+        /// </summary>
+        /// <param name="schematic">The Schematic of the Machine</param>
+        /// <param name="machineId">The Id of Machine to create; if null, an Id will be generated.</param>
+        /// <param name="metadata">Related metadata for the Machine</param>
+        /// <param name="cancellationToken"></param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="schematic"/> is null.</exception>
+        /// <exception cref="SchematicDoesNotExistException">Thrown when no matching Schematic was found for the given name.</exception>
+        public async Task<MachineStatus<TState, TInput>> CreateMachineAsync(
+            Schematic<TState, TInput> schematic,
+            string machineId,
+            IDictionary<string, string> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            if (schematic == null) throw new ArgumentNullException(nameof(schematic));
+
+            var id = machineId ?? Guid.NewGuid().ToString();
+
+            var schematicJson = MessagePackSerializer.ToJson(
+                obj: schematic, 
+                resolver: ContractlessStandardResolver.Instance);
+
+            var stateJson = MessagePackSerializer.ToJson(
+                obj: schematic.InitialState, 
+                resolver: ContractlessStandardResolver.Instance);
+
+            string metadataJson = null;
+            if (metadata != null)
+                metadataJson = MessagePackSerializer.ToJson(
+                    obj: metadata);
+
+            var commitTag = Guid.NewGuid();
+            var updatedTime = DateTimeOffset.UtcNow;
+
+            var record = new EntityFrameworkCoreMachineStatus
+            {
+                MachineId = id,
+                SchematicJson = schematicJson,
+                StateJson = stateJson,
+                CommitTag = commitTag,
+                UpdatedTime = updatedTime,
+                MetadataJson = metadataJson
+            };
+
+            DbContext.Machines.Add(record);
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+
+            return new MachineStatus<TState, TInput>
+            {
+                MachineId = id,
+                Schematic = schematic.Clone(),
+                State = schematic.InitialState,
+                Metadata = metadata,
+                CommitTag = commitTag,
+                UpdatedTime = updatedTime
+            };
+        }
+
+        public async Task<ICollection<MachineStatus<TState, TInput>>> BulkCreateMachinesAsync(
+            Schematic<TState, TInput> schematic,
+            IEnumerable<IDictionary<string, string>> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            if (schematic == null) throw new ArgumentNullException(nameof(schematic));
+
+            var schematicJson = MessagePackSerializer.ToJson(
+                obj: schematic, 
+                resolver: ContractlessStandardResolver.Instance);
+
+            var stateJson = MessagePackSerializer.ToJson(
+                obj: schematic.InitialState, 
+                resolver: ContractlessStandardResolver.Instance);
+
+            var commitTag = Guid.NewGuid();
+            var updatedTime = DateTimeOffset.UtcNow;
+
+            var records = new List<EntityFrameworkCoreMachineStatus>();
+            var machineStatuses = new List<MachineStatus<TState, TInput>>();
+
+            foreach (var dictionary in metadata)
+            {
+                var machineId = Guid.NewGuid().ToString();
+
+                string metadataJson = null;
+                if (dictionary != null)
+                    metadataJson = MessagePackSerializer.ToJson(
+                        obj: dictionary);
+
+                records.Add(new EntityFrameworkCoreMachineStatus
+                {
+                    MachineId = machineId,
+                    SchematicJson = schematicJson,
+                    StateJson = stateJson,
+                    CommitTag = commitTag,
+                    UpdatedTime = updatedTime,
+                    MetadataJson = metadataJson
+                });
+
+                machineStatuses.Add(new MachineStatus<TState, TInput>
+                {
+                    MachineId = machineId,
+                    Schematic = schematic.Clone(),
+                    State = schematic.InitialState,
+                    Metadata = dictionary,
+                    CommitTag = commitTag,
+                    UpdatedTime = updatedTime
+                });
+            }
+
+            await DbContext.AddRangeAsync(records, cancellationToken);
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+
+            return machineStatuses;
+        }
+
+        public async Task<ICollection<MachineStatus<TState, TInput>>> BulkCreateMachinesAsync(
+            string schematicName,
+            IEnumerable<IDictionary<string, string>> metadata,
+            CancellationToken cancellationToken = default)
+        {
+            var schematic = await RetrieveSchematicAsync(schematicName, cancellationToken).ConfigureAwait(false);
+
+            return await BulkCreateMachinesAsync(schematic, metadata, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Deletes a Machine.
+        /// </summary>
+        /// <remarks>
+        /// Does not throw an exception if a matching Machine was not found.
+        /// </remarks>
+        /// <param name="machineId">The Id of the Machine to delete</param>
+        /// <param name="cancellationToken"></param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="machineId"/> is null.</exception>
+        public async Task DeleteMachineAsync(string machineId, CancellationToken cancellationToken = default)
+        {
+            if (machineId == null) throw new ArgumentNullException(nameof(machineId));
+
+            var machineRecord = await DbContext.Machines
+                .SingleOrDefaultAsync(
+                    status => status.MachineId == machineId,
+                    cancellationToken).ConfigureAwait(false);
+
+            if (machineRecord != null)
+            {
+                DbContext.Machines.Remove(machineRecord);
+
+                await DbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the record for a Machine Status.
+        /// </summary>
+        /// <param name="machineId">The Id of the Machine</param>
+        /// <param name="cancellationToken"></param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="machineId"/> is null.</exception>
+        /// <exception cref="MachineDoesNotExistException">Thrown when no matching MachineId was found.</exception>
+        public async Task<MachineStatus<TState, TInput>> GetMachineStatusAsync(
+            string machineId, 
+            CancellationToken cancellationToken = default)
+        {
+            if (machineId == null) throw new ArgumentNullException(nameof(machineId));
+
+            var machineRecord = await DbContext.Machines
+                .SingleOrDefaultAsync(
+                    status => status.MachineId == machineId,
+                    cancellationToken).ConfigureAwait(false);
+
+            if(machineRecord == null) throw new MachineDoesNotExistException(machineId);
+
+            var schematic = MessagePackSerializer.Deserialize<Schematic<TState, TInput>>(
+                bytes: MessagePackSerializer.FromJson(machineRecord.SchematicJson), 
+                resolver: ContractlessStandardResolver.Instance);
+
+            var state = MessagePackSerializer.Deserialize<TState>(
+                bytes: MessagePackSerializer.FromJson(machineRecord.StateJson),
+                resolver: ContractlessStandardResolver.Instance);
+
+            IDictionary<string, string> metadata = null;
+            if(machineRecord.MetadataJson != null)
+                metadata = MessagePackSerializer.Deserialize<IDictionary<string, string>>(
+                    bytes: MessagePackSerializer.FromJson(machineRecord.MetadataJson));
+
+            return new MachineStatus<TState, TInput>
+            {
+                MachineId = machineId,
+                Schematic = schematic,
+                State = state,
+                Metadata = metadata,
+                CommitTag = machineRecord.CommitTag,
+                UpdatedTime = machineRecord.UpdatedTime
+            };
+        }
+
+        /// <summary>
+        /// Updates the Status record of a Machine
+        /// </summary>
+        /// <param name="machineId">The Id of the Machine</param>
+        /// <param name="state">The state to which the Status is set.</param>
+        /// <param name="lastCommitTag">
+        /// If provided, will guarentee the update will occur only 
+        /// if the value matches the current Status's CommitTag.
+        /// </param>
+        /// <param name="cancellationToken"></param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="machineId"/> is null.</exception>
+        /// <exception cref="MachineDoesNotExistException">Thrown when no matching MachineId was found.</exception>
+        /// <exception cref="StateConflictException">Thrown when a conflict occured on CommitTag; no update was performed.</exception>
+        public async Task<MachineStatus<TState, TInput>> SetMachineStateAsync(
+            string machineId,
+            TState state,
+            Guid? lastCommitTag,
+            CancellationToken cancellationToken = default)
+        {
+            if (machineId == null) throw new ArgumentNullException(nameof(machineId));
+
+            var machineRecord = await DbContext.Machines
+                .SingleOrDefaultAsync(
+                    status => status.MachineId == machineId,
+                    cancellationToken).ConfigureAwait(false);
+
+            if(machineRecord == null) throw new MachineDoesNotExistException(machineId);
+
+            if (lastCommitTag == null || machineRecord.CommitTag == lastCommitTag)
+            {
+                var stateJson = MessagePackSerializer.ToJson(
+                    obj: state, 
+                    resolver: ContractlessStandardResolver.Instance);
+
+                machineRecord.StateJson = stateJson;
+                machineRecord.CommitTag = Guid.NewGuid();
+                machineRecord.UpdatedTime = DateTimeOffset.UtcNow;
+            }
+            else
+            {
+                throw new StateConflictException();
+            }
+
+            try
+            {
+                await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                throw new StateConflictException(ex);
+            }
+
+            var schematic = MessagePackSerializer.Deserialize<Schematic<TState, TInput>>(
+                bytes: MessagePackSerializer.FromJson(machineRecord.SchematicJson), 
+                resolver: ContractlessStandardResolver.Instance);
+
+            IDictionary<string, string> metadata = null;
+            if(machineRecord.MetadataJson != null)
+                metadata = MessagePackSerializer.Deserialize<IDictionary<string, string>>(
+                    bytes: MessagePackSerializer.FromJson(machineRecord.MetadataJson));
+
+            return new MachineStatus<TState, TInput>
+            {
+                MachineId = machineId,
+                Schematic = schematic,
+                State = state,
+                Metadata = metadata,
+                CommitTag = machineRecord.CommitTag,
+                UpdatedTime = machineRecord.UpdatedTime
+            };
+        }
+
+        #region IDisposable Support
+        // To detect redundant calls
+        private bool _disposedValue;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    DbContext.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+        #endregion
+
+    }
+}

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/EntityFrameworkCoreRepositoryComponent.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/EntityFrameworkCoreRepositoryComponent.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using REstate.IoC;
+
+namespace REstate.Engine.Repositories.EntityFrameworkCore
+{
+    /// <summary>
+    /// REstate component that configures Entity Framework Core as the state storage system.
+    /// </summary>
+    public class EntityFrameworkCoreRepositoryComponent
+        : IComponent
+    {
+        private readonly REstateEntityFrameworkCoreServerOptions _options;
+
+        /// <summary>
+        /// Creates an instance of the component given configurationusing a <see cref="DbContextOptionsBuilder"/>. />
+        /// </summary>
+        /// <param name="optionsBuilder">The connection options REstate will use</param>
+        public EntityFrameworkCoreRepositoryComponent(Action<DbContextOptionsBuilder> optionsBuilder)
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            optionsBuilder?.Invoke(builder);
+
+            _options = new REstateEntityFrameworkCoreServerOptions(builder.Options);
+        }
+
+        /// <summary>
+        /// Registers the dependencies of this component and actives necessary configuration
+        /// </summary>
+        /// <param name="registrar">The registrar to which the configuration and dependencies should be added</param>
+        public void Register(IRegistrar registrar)
+        {
+            registrar.Register(_options);
+            registrar.Register(typeof(IRepositoryContextFactory<,>), typeof(EntityFrameworkCoreRepositoryContextFactory<,>));
+        }
+    }
+
+}

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/EntityFrameworkCoreRepositoryContextFactory.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/EntityFrameworkCoreRepositoryContextFactory.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace REstate.Engine.Repositories.EntityFrameworkCore
+{
+
+    public class EntityFrameworkCoreRepositoryContextFactory<TState, TInput>
+        : IRepositoryContextFactory<TState, TInput>
+    {
+        internal EntityFrameworkCoreRepositoryContextFactory(REstateEntityFrameworkCoreServerOptions options)
+        {
+            Options = options;
+        }
+
+        private REstateEntityFrameworkCoreServerOptions Options { get; }
+
+        public Task<IEngineRepositoryContext<TState, TInput>> OpenContextAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IEngineRepositoryContext<TState, TInput>>(
+                new EntityFrameworkCoreEngineRepositoryContext<TState, TInput>(
+                    new REstateDbContext(Options.DbContextOptions)));
+        }
+    }
+
+}

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/REstate.Engine.Repositories.EntityFrameworkCore.csproj
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/REstate.Engine.Repositories.EntityFrameworkCore.csproj
@@ -3,11 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="1.7.3.2" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.1" />
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/REstateDbContext.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/REstateDbContext.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace REstate.Engine.Repositories.EntityFrameworkCore
+{
+    public class EntityFrameworkCoreMachineStatus
+    {
+        public string MachineId { get; set; }
+        
+        public Guid CommitTag { get; set; }
+
+        public DateTimeOffset UpdatedTime { get; set; }
+
+        public string StateJson { get; set; }
+
+        public string MetadataJson { get; set; }
+
+        public string SchematicJson { get; set; }
+    }
+
+    public class EntityFrameworkCoreSchematic
+    {
+        public string SchematicName { get; set; }
+
+        public string SchematicJson { get; set; }
+    }
+
+    public class REstateDbContext
+        : DbContext
+    {
+        public REstateDbContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        /// <summary>
+        ///     Override this method to further configure the model that was discovered by convention from the entity types
+        ///     exposed in <see cref="T:Microsoft.EntityFrameworkCore.DbSet`1" /> properties on your derived context. The resulting model may be cached
+        ///     and re-used for subsequent instances of your derived context.
+        /// </summary>
+        /// <remarks>
+        ///     If a model is explicitly set on the options for this context 
+        ///     (via <see cref="M:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.UseModel(Microsoft.EntityFrameworkCore.Metadata.IModel)" />)
+        ///     then this method will not be run.
+        /// </remarks>
+        /// <param name="modelBuilder">
+        ///     The builder being used to construct the model for this context. Databases (and other extensions) typically
+        ///     define extension methods on this object that allow you to configure aspects of the model that are specific
+        ///     to a given database.
+        /// </param>
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<EntityFrameworkCoreMachineStatus>()
+                .HasKey(status => status.MachineId);
+
+            modelBuilder.Entity<EntityFrameworkCoreMachineStatus>()
+                .Property(status => status.CommitTag)
+                .IsConcurrencyToken();
+
+            modelBuilder.Entity<EntityFrameworkCoreSchematic>()
+                .HasKey(schematic => schematic.SchematicName);
+        }
+
+        public DbSet<EntityFrameworkCoreMachineStatus> Machines { get; set; }
+
+        public DbSet<EntityFrameworkCoreSchematic> Schematics { get; set; }
+    }
+}

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/REstateEntityFrameworkCoreServerOptions.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/REstateEntityFrameworkCoreServerOptions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace REstate.Engine.Repositories.EntityFrameworkCore
+{
+    internal class REstateEntityFrameworkCoreServerOptions
+    {
+        public REstateEntityFrameworkCoreServerOptions(DbContextOptions dbContextOptions)
+        {
+            DbContextOptions = dbContextOptions;
+        }
+
+        public DbContextOptions DbContextOptions { get; }
+    }
+
+}

--- a/src/REstate.Engine.Repositories.Redis/REstate.Engine.Repositories.Redis.csproj
+++ b/src/REstate.Engine.Repositories.Redis/REstate.Engine.Repositories.Redis.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="1.7.2" />
+    <PackageReference Include="MessagePack" Version="1.7.3.2" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
   </ItemGroup>

--- a/src/REstate.Remote/GrpcRemoteHostComponent.cs
+++ b/src/REstate.Remote/GrpcRemoteHostComponent.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Grpc.Core;
-using MagicOnion.Client;
 using REstate.Engine;
 using REstate.Remote.Services;
 using REstate.IoC;

--- a/src/REstate.Remote/GrpcStateEngine.cs
+++ b/src/REstate.Remote/GrpcStateEngine.cs
@@ -95,17 +95,18 @@ namespace REstate.Remote
             return new GrpcStateMachine<TState, TInput>(_stateMachineService, response.MachineId);
         }
 
-        public Task BulkCreateMachinesAsync(
+        public Task<IEnumerable<IStateMachine<TState, TInput>>> BulkCreateMachinesAsync(
             ISchematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default)
             => BulkCreateMachinesAsync(schematic.Clone(), metadata, cancellationToken);
 
-        public async Task BulkCreateMachinesAsync(
+        public async Task<IEnumerable<IStateMachine<TState, TInput>>> BulkCreateMachinesAsync(
             Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default)
-            => await _stateMachineService
+        {
+            var response = await _stateMachineService
                 .WithCancellationToken(cancellationToken)
                 .BulkCreateMachineFromSchematicAsync(new BulkCreateMachineFromSchematicRequest
                 {
@@ -113,17 +114,24 @@ namespace REstate.Remote
                     Metadata = metadata
                 });
 
-        public async Task BulkCreateMachinesAsync(
+            return response.MachineIds.Select(machineId => new GrpcStateMachine<TState, TInput>(_stateMachineService, machineId));
+        }
+
+        public async Task<IEnumerable<IStateMachine<TState, TInput>>> BulkCreateMachinesAsync(
             string schematicName,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default)
-            => await _stateMachineService
+        {
+            var response = await _stateMachineService
                 .WithCancellationToken(cancellationToken)
                 .BulkCreateMachineFromStoreAsync(new BulkCreateMachineFromStoreRequest
                 {
                     SchematicName = schematicName,
                     Metadata = metadata
                 });
+
+            return response.MachineIds.Select(machineId => new GrpcStateMachine<TState, TInput>(_stateMachineService, machineId));
+        }
 
         public async Task DeleteMachineAsync(
             string machineId,

--- a/src/REstate.Remote/Models/BulkCreateMachine.cs
+++ b/src/REstate.Remote/Models/BulkCreateMachine.cs
@@ -22,4 +22,11 @@ namespace REstate.Remote.Models
         [Key(1)]
         public IEnumerable<IDictionary<string, string>> Metadata { get; set; }
     }
+
+    [MessagePackObject]
+    public class BulkCreateMachineResponse
+    {
+        [Key(0)]
+        public IEnumerable<string> MachineIds { get; set; }
+    }
 }

--- a/src/REstate.Remote/REstate.Remote.csproj
+++ b/src/REstate.Remote/REstate.Remote.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc" Version="1.8.0" />
+    <PackageReference Include="Grpc" Version="1.8.3" />
     <PackageReference Include="MagicOnion" Version="0.5.2.0" />
-    <PackageReference Include="MessagePack" Version="1.7.2" />
+    <PackageReference Include="MessagePack" Version="1.7.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/REstate.Remote/Services/IStateMachineService.cs
+++ b/src/REstate.Remote/Services/IStateMachineService.cs
@@ -25,8 +25,8 @@ namespace REstate.Remote.Services
 
         UnaryResult<CreateMachineResponse> CreateMachineFromSchematicAsync(CreateMachineFromSchematicRequest request);
 
-        UnaryResult<Nil> BulkCreateMachineFromStoreAsync(BulkCreateMachineFromStoreRequest request);
+        UnaryResult<BulkCreateMachineResponse> BulkCreateMachineFromStoreAsync(BulkCreateMachineFromStoreRequest request);
 
-        UnaryResult<Nil> BulkCreateMachineFromSchematicAsync(BulkCreateMachineFromSchematicRequest request);
+        UnaryResult<BulkCreateMachineResponse> BulkCreateMachineFromSchematicAsync(BulkCreateMachineFromSchematicRequest request);
     }
 }

--- a/src/REstate.Remote/Services/IStateMachineServiceLocalAdapter.cs
+++ b/src/REstate.Remote/Services/IStateMachineServiceLocalAdapter.cs
@@ -9,8 +9,8 @@ namespace REstate.Remote.Services
 {
     internal interface IStateMachineServiceLocalAdapter
     {
-        Task BulkCreateMachineFromSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, IEnumerable<IDictionary<string, string>> metadata, CancellationToken cancellationToken = default);
-        Task BulkCreateMachineFromStoreAsync<TState, TInput>(string schematicName, IEnumerable<IDictionary<string, string>> metadata, CancellationToken cancellationToken = default);
+        Task<BulkCreateMachineResponse> BulkCreateMachineFromSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, IEnumerable<IDictionary<string, string>> metadata, CancellationToken cancellationToken = default);
+        Task<BulkCreateMachineResponse> BulkCreateMachineFromStoreAsync<TState, TInput>(string schematicName, IEnumerable<IDictionary<string, string>> metadata, CancellationToken cancellationToken = default);
         Task<CreateMachineResponse> CreateMachineFromSchematicAsync<TState, TInput>(Schematic<TState, TInput> schematic, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
         Task<CreateMachineResponse> CreateMachineFromStoreAsync<TState, TInput>(string schematicName, string machineId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
         Task DeleteMachineAsync<TState, TInput>(string machineId, CancellationToken cancellationToken);

--- a/src/REstate.Remote/Services/StateMachineService.cs
+++ b/src/REstate.Remote/Services/StateMachineService.cs
@@ -25,8 +25,8 @@ namespace REstate.Remote.Services
     using GetMachineMetadataAsyncDelegate = Func<string, CancellationToken, Task<GetMachineMetadataResponse>>;
     using CreateMachineFromStoreAsyncDelegate = Func<string, string, IDictionary<string, string>, CancellationToken, Task<CreateMachineResponse>>;
     using CreateMachineFromSchematicAsyncDelegate = Func<object, string, IDictionary<string, string>, CancellationToken, Task<CreateMachineResponse>>;
-    using BulkCreateMachineFromStoreAsyncDelegate = Func<string, IEnumerable<IDictionary<string, string>>, CancellationToken, Task>;
-    using BulkCreateMachineFromSchematicAsyncDelegate = Func<object, IEnumerable<IDictionary<string, string>>, CancellationToken, Task>;
+    using BulkCreateMachineFromStoreAsyncDelegate = Func<string, IEnumerable<IDictionary<string, string>>, CancellationToken, Task<BulkCreateMachineResponse>>;
+    using BulkCreateMachineFromSchematicAsyncDelegate = Func<object, IEnumerable<IDictionary<string, string>>, CancellationToken, Task<BulkCreateMachineResponse>>;
     using GetSchematicAsyncDelegate = Func<string, CancellationToken, Task<GetSchematicResponse>>;
     using DeleteMachineAsyncDelegate = Func<string, CancellationToken, Task>;
 
@@ -373,7 +373,7 @@ namespace REstate.Remote.Services
                 GetCallCancellationToken());
         }
         
-        public async UnaryResult<Nil> BulkCreateMachineFromStoreAsync(BulkCreateMachineFromStoreRequest request)
+        public async UnaryResult<BulkCreateMachineResponse> BulkCreateMachineFromStoreAsync(BulkCreateMachineFromStoreRequest request)
         {
             var genericTypes = GetGenericsFromHeaders();
 
@@ -408,12 +408,10 @@ namespace REstate.Remote.Services
                                 .Compile();
                         });
 
-            await bulkCreateMachineFromStoreAsync(request.SchematicName, request.Metadata, GetCallCancellationToken());
-
-            return Nil.Default;
+            return await bulkCreateMachineFromStoreAsync(request.SchematicName, request.Metadata, GetCallCancellationToken());
         }
         
-        public async UnaryResult<Nil> BulkCreateMachineFromSchematicAsync(BulkCreateMachineFromSchematicRequest request)
+        public async UnaryResult<BulkCreateMachineResponse> BulkCreateMachineFromSchematicAsync(BulkCreateMachineFromSchematicRequest request)
         {
             var genericTypes = GetGenericsFromHeaders();
 
@@ -454,9 +452,7 @@ namespace REstate.Remote.Services
                             .Compile();
                     });
 
-            await bulkCreateMachineFromSchematicAsync(schematic, request.Metadata, GetCallCancellationToken());
-
-            return Nil.Default;
+            return await bulkCreateMachineFromSchematicAsync(schematic, request.Metadata, GetCallCancellationToken());
         }
         
         public async UnaryResult<GetSchematicResponse> GetSchematicAsync(GetSchematicRequest request)

--- a/src/REstate.Remote/Services/StateMachineServiceLocalAdapter.cs
+++ b/src/REstate.Remote/Services/StateMachineServiceLocalAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -190,7 +191,7 @@ namespace REstate.Remote.Services
             };
         }
 
-        public async Task BulkCreateMachineFromStoreAsync<TState, TInput>(
+        public async Task<BulkCreateMachineResponse> BulkCreateMachineFromStoreAsync<TState, TInput>(
             string schematicName,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default)
@@ -199,10 +200,15 @@ namespace REstate.Remote.Services
                 .AsLocal()
                 .GetStateEngine<TState, TInput>();
 
-            await engine.BulkCreateMachinesAsync(schematicName, metadata, cancellationToken);
+            var machines = await engine.BulkCreateMachinesAsync(schematicName, metadata, cancellationToken);
+
+            return new BulkCreateMachineResponse
+            {
+                MachineIds = machines.Select(machine => machine.MachineId)
+            };
         }
 
-        public async Task BulkCreateMachineFromSchematicAsync<TState, TInput>(
+        public async Task<BulkCreateMachineResponse> BulkCreateMachineFromSchematicAsync<TState, TInput>(
             Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default)
@@ -211,7 +217,12 @@ namespace REstate.Remote.Services
                 .AsLocal()
                 .GetStateEngine<TState, TInput>();
 
-            await engine.BulkCreateMachinesAsync(schematic, metadata, cancellationToken);
+            var machines = await engine.BulkCreateMachinesAsync(schematic, metadata, cancellationToken);
+            
+            return new BulkCreateMachineResponse
+            {
+                MachineIds = machines.Select(machine => machine.MachineId)
+            };
         }
 
         public async Task<GetSchematicResponse> GetSchematicAsync<TState, TInput>(

--- a/src/REstate/Engine/IStateEngine.cs
+++ b/src/REstate/Engine/IStateEngine.cs
@@ -40,17 +40,17 @@ namespace REstate.Engine
             IDictionary<string, string> metadata = null,
             CancellationToken cancellationToken = default);
 
-        Task BulkCreateMachinesAsync(
+        Task<IEnumerable<IStateMachine<TState, TInput>>> BulkCreateMachinesAsync(
             Schematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default);
 
-        Task BulkCreateMachinesAsync(
+        Task<IEnumerable<IStateMachine<TState, TInput>>> BulkCreateMachinesAsync(
             ISchematic<TState, TInput> schematic,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default);
 
-        Task BulkCreateMachinesAsync(
+        Task<IEnumerable<IStateMachine<TState, TInput>>> BulkCreateMachinesAsync(
             string schematicName,
             IEnumerable<IDictionary<string, string>> metadata,
             CancellationToken cancellationToken = default);

--- a/test/ManualTestCases.playlist
+++ b/test/ManualTestCases.playlist
@@ -1,0 +1,1 @@
+<Playlist Version="1.0"><Add Test="REstate.Engine.Repositories.EntityFrameworkCore.Tests.ProviderValidationTests.ConcurrencyCheckIsSupported" /></Playlist>

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/Context/REstateEntityFrameworkCoreContext.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/Context/REstateEntityFrameworkCoreContext.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using REstate.Tests.Features.Context;
+
+namespace REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features.Context
+{
+    public class REstateEntityFrameworkCoreContext<TState, TInput>
+        : REstateContext<TState, TInput>
+    {
+        #region GIVEN
+        public Task Given_EntityFrameworkCore_is_the_registered_repository()
+        {
+            CurrentHost.Agent().Configuration
+                .RegisterComponent(new EntityFrameworkCoreRepositoryComponent(builder => builder.UseInMemoryDatabase("REstateScenarioTests")));
+
+            return Task.CompletedTask;
+        }
+        #endregion
+
+        #region WHEN
+
+        #endregion
+
+        #region THEN
+
+        #endregion
+    }
+}

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/MachineCreation.cs
@@ -2,22 +2,21 @@ using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
-using REstate.Remote.Tests.Features.Context;
+using REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features.Context;
 using REstate.Tests.Features.Templates;
 
 // ReSharper disable InconsistentNaming
 
-namespace REstate.Remote.Tests.Features
+namespace REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features
 {
     [FeatureDescription(@"
-In order to support cloud scaling
+In order to use familiar storage
 As a developer
-I want to create Machines from Schematics on a remote server")]
+I want to create Machines from Schematics stored using Entity Framework Core")]
     [ScenarioCategory("Machine Creation")]
-    [ScenarioCategory("Remote")]
-    [ScenarioCategory("gRPC")]
+    [ScenarioCategory("EntityFrameworkCore")]
     public class MachineCreation
-        : MachineCreationScenarios<REstateRemoteContext<string, string>>
+        : MachineCreationScenarios<REstateEntityFrameworkCoreContext<string, string>>
     {
         protected override Task<CompositeStep> Given_host_configuration_is_applied()
         {
@@ -26,8 +25,7 @@ I want to create Machines from Schematics on a remote server")]
                     .DefineNew()
                     .WithContext(Context)
                     .AddAsyncSteps(
-                        _ => _.Given_a_REstate_gRPC_Server_running(),
-                        _ => _.Given_the_default_agent_is_gRPC_remote())
+                        _ => _.Given_EntityFrameworkCore_is_the_registered_repository())
                     .Build());
         }
     }

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/MachineDeletion.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/MachineDeletion.cs
@@ -2,23 +2,22 @@
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
-using REstate.Remote.Tests.Features.Context;
+using REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features.Context;
 using REstate.Tests.Features.Templates;
 
 // ReSharper disable InconsistentNaming
 
-namespace REstate.Remote.Tests.Features
+namespace REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features
 {
     [FeatureDescription(@"
-In order to support cloud scaling
+In order to use familiar storage
 As a developer
-I want to retrieve Machines from a remote server")]
-    [ScenarioCategory("Machine Retrieval")]
-    [ScenarioCategory("Remote")]
-    [ScenarioCategory("gRPC")]
-    public class MachineRetrieval
-        : MachineRetrievalScenarios<REstateRemoteContext<string, string>>
-    {        
+I want to delete previously created Machines stored using Entity Framework Core")]
+    [ScenarioCategory("Machine Deletion")]
+    [ScenarioCategory("EntityFrameworkCore")]
+    public class MachineDeletion
+        : MachineDeletionScenarios<REstateEntityFrameworkCoreContext<string, string>>
+    {
         protected override Task<CompositeStep> Given_host_configuration_is_applied()
         {
             return Task.FromResult(
@@ -26,8 +25,7 @@ I want to retrieve Machines from a remote server")]
                     .DefineNew()
                     .WithContext(Context)
                     .AddAsyncSteps(
-                        _ => _.Given_a_REstate_gRPC_Server_running(),
-                        _ => _.Given_the_default_agent_is_gRPC_remote())
+                        _ => _.Given_EntityFrameworkCore_is_the_registered_repository())
                     .Build());
         }
     }

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/MachineRetrieval.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/MachineRetrieval.cs
@@ -2,22 +2,21 @@
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
-using REstate.Remote.Tests.Features.Context;
+using REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features.Context;
 using REstate.Tests.Features.Templates;
 
 // ReSharper disable InconsistentNaming
 
-namespace REstate.Remote.Tests.Features
+namespace REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features
 {
     [FeatureDescription(@"
-In order to support cloud scaling
+In order to use familiar storage
 As a developer
-I want to retrieve Machines from a remote server")]
+I want to retrieve previously created Machines stored using Entity Framework Core")]
     [ScenarioCategory("Machine Retrieval")]
-    [ScenarioCategory("Remote")]
-    [ScenarioCategory("gRPC")]
+    [ScenarioCategory("EntityFrameworkCore")]
     public class MachineRetrieval
-        : MachineRetrievalScenarios<REstateRemoteContext<string, string>>
+        : MachineRetrievalScenarios<REstateEntityFrameworkCoreContext<string, string>>
     {        
         protected override Task<CompositeStep> Given_host_configuration_is_applied()
         {
@@ -26,8 +25,7 @@ I want to retrieve Machines from a remote server")]
                     .DefineNew()
                     .WithContext(Context)
                     .AddAsyncSteps(
-                        _ => _.Given_a_REstate_gRPC_Server_running(),
-                        _ => _.Given_the_default_agent_is_gRPC_remote())
+                        _ => _.Given_EntityFrameworkCore_is_the_registered_repository())
                     .Build());
         }
     }

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Properties/AssemblyInfo.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using LightBDD.XUnit2;
+
+[assembly:LightBddScope]

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/ProviderValidationTests.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/ProviderValidationTests.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace REstate.Engine.Repositories.EntityFrameworkCore.Tests
+{
+    /// <summary>
+    /// Tests providers to ensure they support required features for REstate.
+    /// </summary>
+    public class ProviderValidationTests
+    {
+        public static object[][] Providers = 
+        {
+            new object[] { new Provider("InMemory", builder => builder.UseInMemoryDatabase("InMemory")) },
+            
+            // Uncomment below to run provider specific tests that require external databases
+            /*
+            new object[] { new Provider("SqlServer", builder => builder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=REstateEfTests;Trusted_Connection=True;MultipleActiveResultSets=true")) }
+            */
+        };
+
+        [Theory]
+        [MemberData(nameof(Providers))]
+        public async Task ConcurrencyCheckIsSupported(Provider provider)
+        {
+            // Arrange
+            var contextFactory = new SampleDbContextFactory(provider.Action);
+
+            var id = Guid.NewGuid();
+
+            using (var dbContext = contextFactory.CreateContext())
+            {
+                await dbContext.Database.EnsureDeletedAsync();
+                await dbContext.Database.EnsureCreatedAsync();
+
+                dbContext.Data.Add(new Datum
+                {
+                    Id = id,
+                    Counter = 0,
+                    CommitTag = Guid.NewGuid()
+                });
+
+                await dbContext.SaveChangesAsync();
+            }
+
+            async Task ModifyDataAsync()
+            {
+                while (true)
+                {
+                    using (var dbContext = contextFactory.CreateContext())
+                    {
+                        var entity = await dbContext.Data.SingleAsync(datum => datum.Id == id);
+
+                        entity.Counter++;
+                        entity.CommitTag = Guid.NewGuid();
+
+                        try
+                        {
+                            await dbContext.SaveChangesAsync();
+                        }
+                        catch (DbUpdateConcurrencyException)
+                        {
+                            continue;
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            // Act
+            var t1 = Task.Run(async () => await ModifyDataAsync());
+            var t2 = Task.Run(async () => await ModifyDataAsync());
+            var t3 = Task.Run(async () => await ModifyDataAsync());
+            var t4 = Task.Run(async () => await ModifyDataAsync());
+
+            await Task.WhenAll(t1, t2, t3, t4);
+
+            Datum result;
+            using (var dbContext = contextFactory.CreateContext())
+            {
+                result = await dbContext.Data.SingleAsync(datum => datum.Id == id);
+            }
+
+            // Assert
+
+            Assert.Equal(4, result.Counter);
+        }
+
+        public class SampleDbContextFactory
+        {
+            private DbContextOptions Options { get; }
+
+            public SampleDbContextFactory(Action<DbContextOptionsBuilder> providerAction)
+            {
+                var builder = new DbContextOptionsBuilder();
+
+                providerAction(builder);
+
+                Options = builder.Options;
+            }
+
+            public SampleDbContext CreateContext()
+            {
+                return new SampleDbContext(Options);
+            }
+        }
+
+        public class SampleDbContext
+            : DbContext
+        {
+            public SampleDbContext(DbContextOptions options)
+            : base(options)
+            {
+                
+            }
+
+            public DbSet<Datum> Data { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<Datum>()
+                    .HasKey(datum => datum.Id);
+
+                modelBuilder.Entity<Datum>()
+                    .Property(datum => datum.CommitTag)
+                    .IsConcurrencyToken();
+            }
+        }
+
+        public class Datum
+        {
+            public Guid Id { get; set; }
+
+            public int Counter { get; set; }
+
+            public Guid CommitTag { get; set; }
+        }
+
+        public class Provider
+        {
+            public Provider(string name, Action<DbContextOptionsBuilder> action)
+            {
+                Name = name;
+                Action = action;
+            }
+
+            public string Name { get; }
+
+            public Action<DbContextOptionsBuilder> Action { get; }
+
+            /// <summary>Returns a string that represents the current object.</summary>
+            /// <returns>A string that represents the current object.</returns>
+            public override string ToString()
+            {
+                return Name;
+            }
+        }
+    }
+}

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/REstate.Engine.Repositories.EntityFrameworkCore.Tests.csproj
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/REstate.Engine.Repositories.EntityFrameworkCore.Tests.csproj
@@ -16,6 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="LightBDD.XUnit2" Version="2.3.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0-preview1-27954" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
@@ -24,7 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\REstate\REstate.csproj" />
+    <ProjectReference Include="..\..\src\REstate.Engine.Repositories.EntityFrameworkCore\REstate.Engine.Repositories.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\REstate.Tests\REstate.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/REstate.Remote.Tests/Features/Context/REstateRemoteContext.cs
+++ b/test/REstate.Remote.Tests/Features/Context/REstateRemoteContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Grpc.Core;
 using REstate.Tests.Features.Context;
 using Xunit;
@@ -20,27 +17,8 @@ namespace REstate.Remote.Tests.Features.Context
     public class REstateRemoteContext<TState, TInput>
         : REstateContext<TState, TInput>
     {
+        #region GIVEN
         public Task Given_a_REstate_gRPC_Server_running()
-        {
-            if (CurrentGrpcServer == null)
-            {
-                lock (CurrentGrpcServerSyncRoot)
-                {
-                    if (CurrentGrpcServer == null)
-                    {
-                        CurrentGrpcServer = CurrentHost.Agent()
-                            .AsRemote()
-                            .CreateGrpcServer(new ServerPort("0.0.0.0", 0, ServerCredentials.Insecure));
-                    }
-                }
-            }
-
-            CurrentGrpcServer.Start();
-
-            return Task.CompletedTask;
-        }
-
-        public Task When_a_REstate_gRPC_Server_is_created_and_started()
         {
             if (CurrentGrpcServer == null)
             {
@@ -72,6 +50,35 @@ namespace REstate.Remote.Tests.Features.Context
             return Task.CompletedTask;
         }
 
+        public async Task Given_a_REstate_gRPC_Server_failure()
+        {
+            await CurrentGrpcServer.KillAsync();
+        }
+        #endregion
+
+        #region WHEN
+        public Task When_a_REstate_gRPC_Server_is_created_and_started()
+        {
+            if (CurrentGrpcServer == null)
+            {
+                lock (CurrentGrpcServerSyncRoot)
+                {
+                    if (CurrentGrpcServer == null)
+                    {
+                        CurrentGrpcServer = CurrentHost.Agent()
+                            .AsRemote()
+                            .CreateGrpcServer(new ServerPort("0.0.0.0", 0, ServerCredentials.Insecure));
+                    }
+                }
+            }
+
+            CurrentGrpcServer.Start();
+
+            return Task.CompletedTask;
+        }
+        #endregion
+
+        #region THEN
         public Task Then_REstate_gRPC_Server_has_bound_ports()
         {
             Assert.NotNull(CurrentGrpcServer);
@@ -80,10 +87,6 @@ namespace REstate.Remote.Tests.Features.Context
 
             return Task.CompletedTask;
         }
-
-        public async Task Given_a_REstate_gRPC_Server_failure()
-        {
-            await CurrentGrpcServer.KillAsync();
-        }
+        #endregion
     }
 }

--- a/test/REstate.Remote.Tests/Features/GrpcServer.cs
+++ b/test/REstate.Remote.Tests/Features/GrpcServer.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
 using LightBDD.XUnit2;
 using REstate.Remote.Tests.Features.Context;
+using REstate.Tests.Features.Templates;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace REstate.Remote.Tests.Features
 {
@@ -21,22 +18,15 @@ I want to connect using gRPC to a remote REstate server")]
     [ScenarioCategory("gRPC")]
     [Collection("gRPC")]
     public class GrpcServer
-        : FeatureFixture
+        : REstateFeature<REstateRemoteContext<string, string>>
     {
         [Scenario]
         public async Task REstate_gRPC_Server_Sets_BoundPorts_on_start()
         {
-            await Runner.WithContext<REstateRemoteContext<string, string>>().RunScenarioAsync(
+            await Runner.WithContext(Context).RunScenarioAsync(
                 _ => _.Given_a_new_host(),
                 _ => _.When_a_REstate_gRPC_Server_is_created_and_started(),
                 _ => _.Then_REstate_gRPC_Server_has_bound_ports());
         }
-
-        #region Constructor
-        public GrpcServer(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-        #endregion
     }
 }

--- a/test/REstate.Remote.Tests/Features/MachineDeletion.cs
+++ b/test/REstate.Remote.Tests/Features/MachineDeletion.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios.Contextual;
 using LightBDD.Framework.Scenarios.Extended;
@@ -12,13 +12,13 @@ namespace REstate.Remote.Tests.Features
     [FeatureDescription(@"
 In order to support cloud scaling
 As a developer
-I want to create Machines from Schematics on a remote server")]
-    [ScenarioCategory("Machine Creation")]
+I want to delete Machines from a remote server")]
+    [ScenarioCategory("Machine Deletion")]
     [ScenarioCategory("Remote")]
     [ScenarioCategory("gRPC")]
-    public class MachineCreation
-        : MachineCreationScenarios<REstateRemoteContext<string, string>>
-    {
+    public class MachineDeletion
+        : MachineDeletionScenarios<REstateRemoteContext<string, string>>
+    {        
         protected override Task<CompositeStep> Given_host_configuration_is_applied()
         {
             return Task.FromResult(

--- a/test/REstate.Remote.Tests/REstate.Remote.Tests.csproj
+++ b/test/REstate.Remote.Tests/REstate.Remote.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LightBDD.XUnit2" Version="2.3.2" />
+    <PackageReference Include="LightBDD.XUnit2" Version="2.3.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/REstate.Tests/Features/Configuration.cs
+++ b/test/REstate.Tests/Features/Configuration.cs
@@ -5,7 +5,6 @@ using LightBDD.Framework.Scenarios.Extended;
 using LightBDD.XUnit2;
 using REstate.IoC.BoDi;
 using REstate.Tests.Features.Context;
-using Xunit.Abstractions;
 
 // ReSharper disable InconsistentNaming
 
@@ -42,12 +41,5 @@ I want to use the configuration")]
                 _ => _.Then_configuration_is_not_null(),
                 _ => _.Then_configuration_has_a_container());
         }
-
-        #region Constructor
-        public Configuration(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-        #endregion
     }
 }

--- a/test/REstate.Tests/Features/Context/Configuration.cs
+++ b/test/REstate.Tests/Features/Context/Configuration.cs
@@ -8,6 +8,11 @@ namespace REstate.Tests.Features.Context
     {
         public IHostConfiguration CurrentHostConfiguration { get; set; }
 
+        #region GIVEN
+
+        #endregion
+
+        #region WHEN
         public Task When_configuration_is_accessed()
         {
             try
@@ -21,7 +26,9 @@ namespace REstate.Tests.Features.Context
 
             return Task.CompletedTask;
         }
+        #endregion
 
+        #region THEN
         public Task Then_configuration_has_a_container()
         {
             Assert.NotNull(((HostConfiguration)CurrentHostConfiguration).Container);
@@ -35,5 +42,7 @@ namespace REstate.Tests.Features.Context
 
             return Task.CompletedTask;
         }
+        #endregion
+
     }
 }

--- a/test/REstate.Tests/Features/Context/Host.cs
+++ b/test/REstate.Tests/Features/Context/Host.cs
@@ -11,6 +11,7 @@ namespace REstate.Tests.Features.Context
 
         public Exception CurrentException { get; set; }
 
+        #region GIVEN
         public Task Given_a_new_host()
         {
             CurrentHost = new REstateHost();
@@ -24,12 +25,19 @@ namespace REstate.Tests.Features.Context
 
             return Task.CompletedTask;
         }
+        #endregion
 
+        #region WHEN
+
+        #endregion
+
+        #region THEN
         public Task Then_no_exception_was_thrown()
         {
             Assert.Null(CurrentException);
 
             return Task.CompletedTask;
         }
+        #endregion
     }
 }

--- a/test/REstate.Tests/Features/Context/Machines.cs
+++ b/test/REstate.Tests/Features/Context/Machines.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using REstate.Engine;
 using REstate.Schematics;
@@ -11,6 +13,18 @@ namespace REstate.Tests.Features.Context
     {
         public IStateMachine<TState, TInput> CurrentMachine { get; set; }
 
+        public List<IStateMachine<TState, TInput>> BulkCreatedMachines { get; set; }
+
+        #region GIVEN
+        public async Task Given_a_Machine_exists_with_MachineId_MACHINEID(Schematic<TState, TInput> schematic, string machineId)
+        {
+            CurrentMachine = await CurrentHost.Agent()
+                .GetStateEngine<TState, TInput>()
+                .CreateMachineAsync(schematic, machineId);
+        }
+        #endregion
+
+        #region WHEN
         public async Task When_a_Machine_is_created_from_a_Schematic(Schematic<TState, TInput> schematic)
         {
             try
@@ -38,6 +52,34 @@ namespace REstate.Tests.Features.Context
                 CurrentException = ex;
             }
 
+        }
+
+        public async Task When_MACHINECOUNT_Machines_are_bulk_created_from_a_SchematicName(string schematicName, int machineCount)
+        {
+            try
+            {
+                BulkCreatedMachines = (await CurrentHost.Agent()
+                    .GetStateEngine<TState, TInput>()
+                    .BulkCreateMachinesAsync(schematicName, Enumerable.Repeat(new Dictionary<string, string>(0), machineCount))).ToList();
+            }
+            catch (Exception ex)
+            {
+                CurrentException = ex;
+            }
+        }
+
+        public async Task When_MACHINECOUNT_Machines_are_bulk_created_from_a_Schematic(ISchematic<TState, TInput> schematic, int machineCount)
+        {
+            try
+            {
+                BulkCreatedMachines = (await CurrentHost.Agent()
+                    .GetStateEngine<TState, TInput>()
+                    .BulkCreateMachinesAsync(schematic, Enumerable.Repeat(new Dictionary<string, string>(0), machineCount))).ToList();
+            }
+            catch (Exception ex)
+            {
+                CurrentException = ex;
+            }
         }
 
         public async Task When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(
@@ -70,29 +112,6 @@ namespace REstate.Tests.Features.Context
             }
         }
 
-        public Task Then_the_Machine_is_valid(IStateMachine<TState, TInput> machine)
-        {
-            Assert.NotNull(machine);
-            Assert.NotNull(machine.MachineId);
-            Assert.NotEmpty(machine.MachineId);
-
-            return Task.CompletedTask;
-        }
-
-        public Task Then_the_MachineId_is_MACHINEID(IStateMachine<TState, TInput> machine, string machineId)
-        {
-            Assert.Equal(machineId, CurrentMachine.MachineId);
-
-            return Task.CompletedTask;
-        }
-
-        public async Task Given_a_Machine_exists_with_MachineId_MACHINEID(Schematic<TState, TInput> schematic, string machineId)
-        {
-            CurrentMachine = await CurrentHost.Agent()
-                .GetStateEngine<TState, TInput>()
-                .CreateMachineAsync(schematic, machineId);
-        }
-
         public async Task When_a_Machine_is_retrieved_with_MachineId_MACHINEID(string machineId)
         {
             try
@@ -108,6 +127,60 @@ namespace REstate.Tests.Features.Context
             }
         }
 
+        public async Task When_a_Machine_is_deleted_with_MachineId_MACHINEID(string machineId)
+        {
+            try
+            {
+                await CurrentHost.Agent()
+                    .GetStateEngine<TState, TInput>()
+                    .DeleteMachineAsync(machineId);
+            }
+            catch (Exception ex)
+            {
+                CurrentException = ex;
+            }
+        }
+        #endregion
+        
+        #region THEN
+        public Task Then_the_Machine_is_valid(IStateMachine<TState, TInput> machine)
+        {
+            Assert.NotNull(machine);
+            Assert.NotNull(machine.MachineId);
+            Assert.NotEmpty(machine.MachineId);
+
+            return Task.CompletedTask;
+        }
+
+        public Task Then_MACHINECOUNT_Machines_were_created(
+            List<IStateMachine<TState, TInput>> bulkCreatedMachines, 
+            int machineCount)
+        {
+            Assert.NotNull(bulkCreatedMachines);
+            Assert.Equal(machineCount, bulkCreatedMachines.Count);
+
+            return Task.CompletedTask;
+        }
+
+        public Task Then_the_Machines_created_are_valid(List<IStateMachine<TState, TInput>> bulkCreatedMachines)
+        {
+            bulkCreatedMachines.ForEach(machine =>
+            {
+                Assert.NotNull(machine);
+                Assert.NotNull(machine.MachineId);
+                Assert.NotEmpty(machine.MachineId);
+            });
+
+            return Task.CompletedTask;
+        }
+
+        public Task Then_the_MachineId_is_MACHINEID(IStateMachine<TState, TInput> machine, string machineId)
+        {
+            Assert.Equal(machineId, CurrentMachine.MachineId);
+
+            return Task.CompletedTask;
+        }
+
         public Task Then_MachineDoesNotExistException_is_thrown()
         {
             Assert.NotNull(CurrentException);
@@ -115,5 +188,6 @@ namespace REstate.Tests.Features.Context
 
             return Task.CompletedTask;
         }
+        #endregion
     }
 }

--- a/test/REstate.Tests/Features/Context/Schematics.cs
+++ b/test/REstate.Tests/Features/Context/Schematics.cs
@@ -9,6 +9,7 @@ namespace REstate.Tests.Features.Context
     {
         public Schematic<TState, TInput> CurrentSchematic { get; set; }
 
+        #region GIVEN
         public Task Given_a_Schematic_with_an_initial_state_INITIALSTATE(string schematicName, TState initialState)
         {
             CurrentSchematic = CurrentHost.Agent()
@@ -26,5 +27,14 @@ namespace REstate.Tests.Features.Context
                 .GetStateEngine<TState, TInput>()
                 .StoreSchematicAsync(schematic);
         }
+        #endregion
+
+        #region WHEN
+
+        #endregion
+
+        #region THEN
+
+        #endregion
     }
 }

--- a/test/REstate.Tests/Features/MachineCreation.cs
+++ b/test/REstate.Tests/Features/MachineCreation.cs
@@ -1,99 +1,13 @@
-﻿using System;
-using System.Reflection;
-using System.Threading.Tasks;
-using LightBDD.Framework;
-using LightBDD.Framework.Scenarios.Contextual;
-using LightBDD.Framework.Scenarios.Extended;
-using LightBDD.XUnit2;
-using REstate.Tests.Features.Context;
-using Xunit.Abstractions;
+﻿using REstate.Tests.Features.Context;
+using REstate.Tests.Features.Templates;
 
 // ReSharper disable InconsistentNaming
 
 namespace REstate.Tests.Features
 {
-    [FeatureDescription(@"
-In order to utilize REstate's functionality
-As a developer
-I want to create machines from schematics")]
-    [ScenarioCategory("Machine Creation")]
     public class MachineCreation
-        : FeatureFixture
+        : MachineCreationScenarios<REstateContext<string, string>>
     {
-        [Scenario]
-        public async Task A_Machine_can_be_created_from_a_Schematic()
-        {
-            var uniqueId = Guid.NewGuid().ToString();
 
-            var schematicName = uniqueId;
-
-            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
-                _ => _.Given_a_new_host(),
-                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
-                _ => _.When_a_Machine_is_created_from_a_Schematic(_.CurrentSchematic),
-                _ => _.Then_no_exception_was_thrown(),
-                _ => _.Then_the_Machine_is_valid(_.CurrentMachine));
-        }
-
-        [Scenario]
-        public async Task A_Machine_can_be_created_from_a_SchematicName()
-        {
-            var uniqueId = Guid.NewGuid().ToString();
-
-            var schematicName = uniqueId;
-
-            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
-                _ => _.Given_a_new_host(),
-                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
-                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
-                _ => _.When_a_Machine_is_created_from_a_SchematicName(_.CurrentSchematic.SchematicName),
-                _ => _.Then_no_exception_was_thrown(),
-                _ => _.Then_the_Machine_is_valid(_.CurrentMachine));
-        }
-
-        [Scenario]
-        public async Task A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
-        {
-            var uniqueId = Guid.NewGuid().ToString();
-
-            var schematicName = uniqueId;
-            var machineId = uniqueId;
-
-            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
-                _ => _.Given_a_new_host(),
-                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
-                _ => _.When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(_.CurrentSchematic, machineId),
-                _ => _.Then_no_exception_was_thrown(),
-                _ => _.Then_the_Machine_is_valid(_.CurrentMachine),
-                _ => _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
-        }
-
-        [Scenario]
-        public async Task A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
-        {
-            var uniqueId = Guid.NewGuid().ToString();
-
-            var schematicName = uniqueId;
-            var machineId = uniqueId;
-
-            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
-                _ => _.Given_a_new_host(),
-                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
-                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
-                _ => _.When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(_.CurrentSchematic.SchematicName, machineId),
-                _ => _.Then_no_exception_was_thrown(),
-                _ => _.Then_the_Machine_is_valid(_.CurrentMachine),
-                _ => _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
-        }
-
-        #region Constructor
-        public MachineCreation(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-        #endregion
     }
-
-
 }
-

--- a/test/REstate.Tests/Features/MachineRetrieval.cs
+++ b/test/REstate.Tests/Features/MachineRetrieval.cs
@@ -1,62 +1,12 @@
-﻿using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Threading.Tasks;
-using LightBDD.Framework;
-using LightBDD.Framework.Scenarios.Contextual;
-using LightBDD.Framework.Scenarios.Extended;
-using LightBDD.XUnit2;
-using REstate.Tests.Features.Context;
-using Xunit.Abstractions;
+﻿using REstate.Tests.Features.Context;
+using REstate.Tests.Features.Templates;
 
 // ReSharper disable InconsistentNaming
 
 namespace REstate.Tests.Features
 {
-    [FeatureDescription(@"
-In order to utilize REstate's functionality
-As a developer
-I want to retrieve previously created machines")]
-    [ScenarioCategory("Machine Retrieval")]
     public class MachineRetrieval
-        : FeatureFixture
+        : MachineRetrievalScenarios<REstateContext<string, string>>
     {
-        [Scenario]
-        public async Task A_Machine_can_be_retrieved()
-        {
-            var uniqueId = Guid.NewGuid().ToString();
-
-            var schematicName = uniqueId;
-            var machineId = uniqueId;
-
-            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
-                _ => _.Given_a_new_host(),
-                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
-                _ => _.Given_a_Machine_exists_with_MachineId_MACHINEID(_.CurrentSchematic, machineId),
-                _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
-                _ => _.Then_no_exception_was_thrown(),
-                _ => _.Then_the_Machine_is_valid(_.CurrentMachine));
-        }
-
-        [Scenario]
-        public async Task A_NonExistant_Machine_cannot_be_retrieved()
-        {
-            var uniqueId = Guid.NewGuid().ToString();
-
-            var machineId = uniqueId;
-
-            await Runner.WithContext<REstateContext<string, string>>().RunScenarioAsync(
-                _ => _.Given_a_new_host(),
-                _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
-                _ => _.Then_MachineDoesNotExistException_is_thrown());
-        }
-
-        #region Constructor
-        public MachineRetrieval(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-        #endregion
     }
 }
-

--- a/test/REstate.Tests/Features/Templates/MachineCreationScenarios.cs
+++ b/test/REstate.Tests/Features/Templates/MachineCreationScenarios.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Threading.Tasks;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios.Contextual;
+using LightBDD.Framework.Scenarios.Extended;
+using LightBDD.XUnit2;
+using REstate.Tests.Features.Context;
+
+// ReSharper disable InconsistentNaming
+
+namespace REstate.Tests.Features.Templates
+{
+    [FeatureDescription(@"
+In order to utilize REstate's functionality
+As a developer
+I want to create machines from schematics")]
+    [ScenarioCategory("Machine Creation")]
+    public abstract class MachineCreationScenarios<TContext>
+        : REstateFeature<TContext>
+        where TContext : REstateContext<string, string>, new()
+    {
+        [Scenario]
+        public async Task A_Machine_can_be_created_from_a_Schematic()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.When_a_Machine_is_created_from_a_Schematic(_.CurrentSchematic),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.Then_the_Machine_is_valid(_.CurrentMachine));
+        }
+
+        [Scenario]
+        public async Task A_Machine_can_be_created_from_a_SchematicName()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
+                _ => _.When_a_Machine_is_created_from_a_SchematicName(_.CurrentSchematic.SchematicName),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.Then_the_Machine_is_valid(_.CurrentMachine));
+        }
+
+        [Scenario]
+        public async Task A_Machine_can_be_created_from_a_Schematic_with_a_predefined_MachineId()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.When_a_Machine_is_created_from_a_Schematic_with_a_predefined_MachineId(_.CurrentSchematic, machineId),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.Then_the_Machine_is_valid(_.CurrentMachine),
+                _ => _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
+        }
+
+        [Scenario]
+        public async Task A_Machine_can_be_created_from_a_SchematicName_with_a_predefined_MachineId()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
+                _ => _.When_a_Machine_is_created_from_a_SchematicName_with_a_predefined_MachineId(_.CurrentSchematic.SchematicName, machineId),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.Then_the_Machine_is_valid(_.CurrentMachine),
+                _ => _.Then_the_MachineId_is_MACHINEID(_.CurrentMachine, machineId));
+        }
+
+        [Scenario]
+        public async Task Machines_can_be_bulk_created_from_a_SchematicName()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Schematic_is_stored(_.CurrentSchematic),
+                _ => _.When_MACHINECOUNT_Machines_are_bulk_created_from_a_SchematicName(_.CurrentSchematic.SchematicName, 5),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.Then_MACHINECOUNT_Machines_were_created(_.BulkCreatedMachines, 5),
+                _ => _.Then_the_Machines_created_are_valid(_.BulkCreatedMachines));
+        }
+
+        [Scenario]
+        public async Task Machines_can_be_bulk_created_from_a_Schematic()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.When_MACHINECOUNT_Machines_are_bulk_created_from_a_Schematic(_.CurrentSchematic, 5),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.Then_MACHINECOUNT_Machines_were_created(_.BulkCreatedMachines, 5),
+                _ => _.Then_the_Machines_created_are_valid(_.BulkCreatedMachines));
+        }
+    }
+}
+

--- a/test/REstate.Tests/Features/Templates/MachineDeletionScenarios.cs
+++ b/test/REstate.Tests/Features/Templates/MachineDeletionScenarios.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Threading.Tasks;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios.Contextual;
+using LightBDD.Framework.Scenarios.Extended;
+using LightBDD.XUnit2;
+using REstate.Tests.Features.Context;
+
+// ReSharper disable InconsistentNaming
+
+namespace REstate.Tests.Features.Templates
+{
+    [FeatureDescription(@"
+In order to utilize REstate's functionality
+As a developer
+I want to retrieve previously created machines")]
+    [ScenarioCategory("Machine Retrieval")]
+    public abstract class MachineRetrievalScenarios<TContext>
+        : REstateFeature<TContext>
+        where TContext : REstateContext<string, string>, new()
+    {
+        [Scenario]
+        public async Task A_Machine_can_be_retrieved()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Machine_exists_with_MachineId_MACHINEID(_.CurrentSchematic, machineId),
+                _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.Then_the_Machine_is_valid(_.CurrentMachine));
+        }
+
+        [Scenario]
+        public async Task A_NonExistant_Machine_cannot_be_retrieved()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var machineId = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
+                _ => _.Then_MachineDoesNotExistException_is_thrown());
+        }
+
+        [Scenario]
+        public async Task A_Machine_that_is_deleted_no_longer_exists()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Machine_exists_with_MachineId_MACHINEID(_.CurrentSchematic, machineId),
+                _ => _.When_a_Machine_is_deleted_with_MachineId_MACHINEID(machineId),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
+                _ => _.Then_MachineDoesNotExistException_is_thrown());
+        }
+    }
+}

--- a/test/REstate.Tests/Features/Templates/MachineRetrievalScenarios.cs
+++ b/test/REstate.Tests/Features/Templates/MachineRetrievalScenarios.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading.Tasks;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios.Contextual;
+using LightBDD.Framework.Scenarios.Extended;
+using LightBDD.XUnit2;
+using REstate.Tests.Features.Context;
+
+// ReSharper disable InconsistentNaming
+
+namespace REstate.Tests.Features.Templates
+{
+    [FeatureDescription(@"
+In order to remove previous executions or stop machines
+As a developer
+I want to delete previously created machines")]
+    [ScenarioCategory("Machine Deletion")]
+    public abstract class MachineDeletionScenarios<TContext>
+        : REstateFeature<TContext>
+        where TContext : REstateContext<string, string>, new()
+    {
+        [Scenario]
+        public async Task A_Machine_that_is_deleted_no_longer_exists()
+        {
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var schematicName = uniqueId;
+            var machineId = uniqueId;
+
+            await Runner.WithContext(Context).RunScenarioAsync(
+                _ => _.Given_a_new_host(),
+                _ =>   Given_host_configuration_is_applied(),
+                _ => _.Given_a_Schematic_with_an_initial_state_INITIALSTATE(schematicName, "Initial"),
+                _ => _.Given_a_Machine_exists_with_MachineId_MACHINEID(_.CurrentSchematic, machineId),
+                _ => _.When_a_Machine_is_deleted_with_MachineId_MACHINEID(machineId),
+                _ => _.Then_no_exception_was_thrown(),
+                _ => _.When_a_Machine_is_retrieved_with_MachineId_MACHINEID(machineId),
+                _ => _.Then_MachineDoesNotExistException_is_thrown());
+        }
+    }
+}

--- a/test/REstate.Tests/Features/Templates/REstateFeature.cs
+++ b/test/REstate.Tests/Features/Templates/REstateFeature.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios.Contextual;
+using LightBDD.XUnit2;
+using REstate.Tests.Features.Context;
+
+// ReSharper disable InconsistentNaming
+
+namespace REstate.Tests.Features.Templates
+{
+    public class REstateFeature<TContext>
+        : FeatureFixture
+        where TContext : REstateContext, new()
+    {
+        protected REstateFeature()
+        {
+            Context = new TContext();
+        }
+
+        protected virtual Task<CompositeStep> Given_host_configuration_is_applied()
+        {
+            return Task.FromResult(
+                CompositeStep
+                    .DefineNew()
+                    .WithContext(Context)
+                    .Build());
+        }
+
+        protected TContext Context { get; }
+    }
+}


### PR DESCRIPTION
:sparkles: Add EntityFramework Core support

- Redesign scenarios into templates to allow easy addition of providers
- Bulk Create returns state machines now instead of void
- Add scenarios for deletion and bulk creation
- Provider tests have to be commented out to run now except in-memory EF core providers

<!--
Requirements
* All new code requires tests to ensure against regressions
-->

<!-- Description of what the objective is and any changes needed -->

<!-- Uncomment the following sections as needed -->

<!-- Explain what other alternates were considered and why the proposed version was selected
### Alternate Designs
-->

<!-- Explain why this functionality should be in REstate as opposed to a community package -->
### Why Should This Be In Core?
Entity Framework is widely used.

<!-- What benefits will be realized by the code change? 
### Benefits
-->

<!-- What are the possible side-effects or negative impacts of the code change?
### Possible Drawbacks
 -->

### Applicable Issues

<!-- Enter any applicable issue numbers here -->
