### PR TITLE
:wrench: Use the official NuGet package for System.Data.SqlClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.DotSettings
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/REstate.Engine.Repositories.EntityFrameworkCore.csproj
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/REstate.Engine.Repositories.EntityFrameworkCore.csproj
@@ -23,17 +23,12 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
     
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\REstate\REstate.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Data.SqlClient">
-      <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\system.data.sqlclient\4.4.0\ref\netstandard2.0\System.Data.SqlClient.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
...instead of relying on a local reference

<!--
Requirements
* All new code requires tests to ensure against regressions
-->

<!-- Description of what the objective is and any changes needed -->
Build relies on the repository existing in a specific location on the build machine, and that machine having `System.Data.SqlClient` exist at a particular location.  Change that reference to the official MS NuGet package for `System.Data.SqlClient`, to make the `REState.Engine.Repositories.EntityFrameworkCore` portable.

<!-- Uncomment the following sections as needed -->

<!-- Explain what other alternates were considered and why the proposed version was selected
### Alternate Designs
-->

<!-- Explain why this functionality should be in REstate as opposed to a community package 
### Why Should This Be In Core?

-->

<!-- What benefits will be realized by the code change? 
### Benefits
-->

<!-- What are the possible side-effects or negative impacts of the code change?
### Possible Drawbacks
 -->

### Applicable Issues

<!-- Enter any applicable issue numbers here -->
