### PR TITLE
Register Agent interfaces and make testable

### DIFF
--- a/src/REstate.Engine.Repositories.Redis/REstate.Engine.Repositories.Redis.csproj
+++ b/src/REstate.Engine.Repositories.Redis/REstate.Engine.Repositories.Redis.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
-    <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/REstate.Remote/GrpcRemoteHostComponent.cs
+++ b/src/REstate.Remote/GrpcRemoteHostComponent.cs
@@ -36,6 +36,8 @@ namespace REstate.Remote
 
             if(_options.UseAsDefaultEngine)
                 registrar.Register(typeof(IStateEngine<,>), typeof(GrpcStateEngine<,>));
+
+            registrar.Register((contianer) => contianer.Resolve<IAgent>().AsRemote());
         }
     }
 }

--- a/src/REstate/Agent.cs
+++ b/src/REstate/Agent.cs
@@ -6,6 +6,11 @@ namespace REstate
     public interface IAgent
     {
         IHostConfiguration Configuration { get; }
+
+        TStateEngine GetStateEngine<TState, TInput, TStateEngine>()
+            where TStateEngine : class, IStateEngine<TState, TInput>;
+
+        IStateEngine<TState, TInput> GetStateEngine<TState, TInput>();
     }
 
     internal class Agent 
@@ -22,5 +27,14 @@ namespace REstate
             ((HostConfiguration)Configuration).Container
                 .Resolve<ICartographer<TState, TInput>>()
                 .WriteMap(schematic);
+
+        public IStateEngine<TState, TInput> GetStateEngine<TState, TInput>() =>
+            ((HostConfiguration)Configuration).Container
+                .Resolve<IStateEngine<TState, TInput>>();
+
+        public TStateEngine GetStateEngine<TState, TInput, TStateEngine>()
+            where TStateEngine : class, IStateEngine<TState, TInput> =>
+            ((HostConfiguration)Configuration).Container
+                .Resolve<TStateEngine>();
     }
 }

--- a/src/REstate/AgentExtensions.cs
+++ b/src/REstate/AgentExtensions.cs
@@ -11,12 +11,5 @@ namespace REstate
 
         public static ILocalAgent AsLocal(this IAgent agent) =>
             new LocalAgent(agent);
-
-        public static IStateEngine<TState, TInput> GetStateEngine<TState, TInput>(this IAgent agent) =>
-            ((HostConfiguration)agent.Configuration).Container.Resolve<IStateEngine<TState, TInput>>();
-
-        public static TStateEngine GetStateEngine<TState, TInput, TStateEngine>(this IAgent agent)
-            where TStateEngine : class, IStateEngine<TState, TInput> =>
-            ((HostConfiguration)agent.Configuration).Container.Resolve<TStateEngine>();
     }
 }

--- a/src/REstate/REstateHost.cs
+++ b/src/REstate/REstateHost.cs
@@ -3,8 +3,6 @@ using System.Linq.Expressions;
 using REstate.Engine;
 using REstate.IoC;
 using REstate.IoC.BoDi;
-using REstate.Logging;
-using REstate.Schematics;
 
 namespace REstate
 {
@@ -37,7 +35,12 @@ namespace REstate
         {
             TryUseContainer(this, new BoDiComponentContainer(new ObjectContainer()));
 
-            return new Agent(HostConfiguration);
+            var agent = new Agent(HostConfiguration);
+
+            HostConfiguration.Container.Register<IAgent>(agent);
+            HostConfiguration.Container.Register(agent.AsLocal());
+
+            return agent;
 
         }
 

--- a/test/REstate.Tests/Units/ActionTests.cs
+++ b/test/REstate.Tests/Units/ActionTests.cs
@@ -1,0 +1,78 @@
+﻿using REstate.Engine;
+using REstate.Engine.Connectors;
+using REstate.IoC;
+using REstate.Schematics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace REstate.Tests.Units
+{
+    public class ActionTests
+    {
+        [Fact]
+        public async Task Action_Can_Depend_On_AgentAsync()
+        {
+            // Arrange
+            var host = new REstateHost();
+
+            host.Agent().Configuration
+                .RegisterConnector<ProcessAction>();
+
+            var schematic = host.Agent()
+                .CreateSchematic<string, string>(
+                    schematicName: nameof(Action_Can_Depend_On_AgentAsync))
+                .WithState("Idle", idle => idle
+                    .AsInitialState())
+                .WithState("Processing", processing => processing
+                    .WithTransitionFrom("Idle", "Process")
+                    .WithAction<ProcessAction>())
+                .WithState("StillProcessing", stillProcessing => stillProcessing
+                    .WithTransitionFrom("Processing", "Continue"))
+                .WithState("Complete", complete => complete
+                    .WithTransitionFrom("StillProcessing", "Complete"));
+
+            var engine = host.Agent().GetStateEngine<string, string>();
+            var machine = await engine.CreateMachineAsync(schematic);
+
+            // Act
+            var status = await machine.SendAsync("Process");
+
+            // Assert
+            Assert.Equal("Processing", status.State);
+        }
+
+        /// <summary>
+        /// An action that depends on Agent
+        /// </summary>
+        public class ProcessAction
+            : IAction<string, string>
+        {
+            public ProcessAction(IAgent agent)
+            {
+                Agent = agent;
+            }
+
+            public IAgent Agent { get; }
+
+            public Task InvokeAsync<TPayload>(
+                ISchematic<string, string> schematic,
+                IStateMachine<string, string> machine,
+                Status<string> status,
+                InputParameters<string, TPayload> inputParameters,
+                IReadOnlyDictionary<string, string> connectorSettings,
+                CancellationToken cancellationToken = default)
+            {
+                // Processing
+                var engine = Agent.GetStateEngine<string, string>();
+
+                return Task.CompletedTask;
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
- Move GetStateEngine extensions to IAgent
- Register IAgent, ILocalAgent, and IRemoteAgent at creation
- Add test that ensure an IAgent can be resolved from an IAction, and used to get a StateEngine

<!--
Requirements
* All new code requires tests to ensure against regressions
-->

<!-- Description of what the objective is and any changes needed -->

<!-- Uncomment the following sections as needed -->

<!-- Explain what other alternates were considered and why the proposed version was selected
### Alternate Designs
-->

<!-- Explain why this functionality should be in REstate as opposed to a community package 
### Why Should This Be In Core?

-->

<!-- What benefits will be realized by the code change? 
### Benefits
-->

<!-- What are the possible side-effects or negative impacts of the code change?
### Possible Drawbacks
 -->

### Applicable Issues

<!-- Enter any applicable issue numbers here -->
