### PR TITLE
Introduced GetMachineReference & IOptimisticallyConcurrentStateRepository to reduce IO ops

### DIFF
--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/RepositoryFactory.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/RepositoryFactory.cs
@@ -18,7 +18,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult<IEngineRepositoryContext<TState, TInput>>(
-                new Repository<TState, TInput>(_dbContextFactory.CreateContext()));
+                new Repository<TState, TInput>(_dbContextFactory));
         }
     }
 

--- a/src/REstate.Remote/GrpcStateEngine.cs
+++ b/src/REstate.Remote/GrpcStateEngine.cs
@@ -168,6 +168,12 @@ namespace REstate.Remote
             return new GrpcStateMachine<TState, TInput>(_stateMachineService, machineId);
         }
 
+        ///<inheritdoc />
+        public IStateMachine<TState, TInput> GetMachineReference(string machineId)
+        {
+            return new GrpcStateMachine<TState, TInput>(_stateMachineService, machineId);
+        }
+
         public async Task<ISchematic<TState, TInput>> GetSchematicAsync(
             string schematicName,
             CancellationToken cancellationToken = default)

--- a/src/REstate/Engine/IStateEngine.cs
+++ b/src/REstate/Engine/IStateEngine.cs
@@ -63,6 +63,15 @@ namespace REstate.Engine
             string machineId,
             CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Returns a reference machine that has not been checked for existence.
+        /// <para />
+        /// Useful for often reloaded machine paths such as request paths.
+        /// </summary>
+        /// <param name="machineId"></param>
+        /// <returns>A Machine reference that defers loading</returns>
+        IStateMachine<TState, TInput> GetMachineReference(string machineId);
+
         Task<ISchematic<TState, TInput>> GetSchematicAsync(
             string schematicName,
             CancellationToken cancellationToken = default);

--- a/src/REstate/Engine/IStateMachineFactory.cs
+++ b/src/REstate/Engine/IStateMachineFactory.cs
@@ -9,5 +9,7 @@ namespace REstate.Engine
             string machineId, 
             ISchematic<TState, TInput> schematic,
             IReadOnlyDictionary<string, string> metadata);
+
+        IStateMachine<TState, TInput> Construct(string machineId);
     }
 }

--- a/src/REstate/Engine/REstateMachineFactory.cs
+++ b/src/REstate/Engine/REstateMachineFactory.cs
@@ -46,5 +46,19 @@ namespace REstate.Engine
 
             return restateMachine;
         }
+
+        public IStateMachine<TState, TInput> Construct(string machineId)
+        {
+            if (machineId == null) throw new ArgumentNullException(nameof(machineId));
+
+            var restateMachine = new REstateMachine<TState, TInput>(
+                _connectorResolver,
+                _repositoryContextFactory,
+                _cartographer,
+                _listeners,
+                machineId);
+
+            return restateMachine;
+        }
     }
 }

--- a/src/REstate/Engine/Repositories/IMachineRepository.cs
+++ b/src/REstate/Engine/Repositories/IMachineRepository.cs
@@ -80,4 +80,14 @@ namespace REstate.Engine.Repositories
             IDictionary<string, string> stateBag = null,
             CancellationToken cancellationToken = default);
     }
+
+    public interface IOptimisticallyConcurrentStateRepository<TState, TInput>
+    {
+        Task<MachineStatus<TState, TInput>> SetMachineStateAsync(
+            MachineStatus<TState, TInput> machineStatus,
+            TState state,
+            long? lastCommitNumber,
+            IDictionary<string, string> stateBag = null,
+            CancellationToken cancellationToken = default);
+    }
 }

--- a/src/REstate/Engine/StateEngine.cs
+++ b/src/REstate/Engine/StateEngine.cs
@@ -388,6 +388,15 @@ namespace REstate.Engine
             return machine;
         }
 
+        public IStateMachine<TState, TInput> GetMachineReference(
+            string machineId,
+            CancellationToken cancellationToken = default)
+        {
+            var machine = _stateMachineFactory.Construct(machineId);
+
+            return machine;
+        }
+
         public async Task DeleteMachineAsync(
             string machineId,
             CancellationToken cancellationToken = default)

--- a/src/REstate/Engine/StateEngine.cs
+++ b/src/REstate/Engine/StateEngine.cs
@@ -388,9 +388,8 @@ namespace REstate.Engine
             return machine;
         }
 
-        public IStateMachine<TState, TInput> GetMachineReference(
-            string machineId,
-            CancellationToken cancellationToken = default)
+        /// <inheritdoc />
+        public IStateMachine<TState, TInput> GetMachineReference(string machineId)
         {
             var machine = _stateMachineFactory.Construct(machineId);
 

--- a/src/REstate/Natural/NaturalStateEngine.cs
+++ b/src/REstate/Natural/NaturalStateEngine.cs
@@ -48,6 +48,8 @@ namespace REstate.Natural
             string machineId,
             CancellationToken cancellationToken = default);
 
+        INaturalStateMachine GetMachineReference(string machineId);
+
         Task<INaturalSchematic> GetSchematicAsync(
             string schematicName,
             CancellationToken cancellationToken = default);
@@ -165,6 +167,14 @@ namespace REstate.Natural
             var machine = await _stateEngine
                 .GetMachineAsync(machineId, cancellationToken)
                 .ConfigureAwait(false);
+
+            return new NaturalStateMachine(machine);
+        }
+
+
+        public INaturalStateMachine GetMachineReference(string machineId)
+        {
+            var machine = _stateEngine.GetMachineReference(machineId);
 
             return new NaturalStateMachine(machine);
         }

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/Context/REstateEntityFrameworkCoreContext.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/Context/REstateEntityFrameworkCoreContext.cs
@@ -9,21 +9,21 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features.Context
         : REstateContext<TState, TInput>
     {
         #region GIVEN
-        public async Task Given_EntityFrameworkCore_is_the_registered_repository()
+        public Task Given_EntityFrameworkCore_is_the_registered_repository()
         {
             var options = new DbContextOptionsBuilder()
-                //.UseInMemoryDatabase("REstateScenarioTests")
-                .UseSqlServer(
-                    "Server=(localdb)\\mssqllocaldb;Database=REstateEfTestsIntegrated;Trusted_Connection=True;MultipleActiveResultSets=true")
+                .UseInMemoryDatabase("REstateScenarioTests")
+                //.UseSqlServer(
+                //    "Server=(localdb)\\mssqllocaldb;Database=REstateEfTestsIntegrated;Trusted_Connection=True;MultipleActiveResultSets=true")
                 .Options;
 
             CurrentHost.Agent().Configuration
                 .RegisterComponent(new EntityFrameworkCoreRepositoryComponent(
                     options));
 
-            await new REstateDbContextFactory(options).CreateContext().Database.EnsureCreatedAsync(CancellationToken.None);
+            //await new REstateDbContextFactory(options).CreateContext().Database.EnsureCreatedAsync(CancellationToken.None);
 
-            //return Task.CompletedTask;
+            return Task.CompletedTask;
         }
         #endregion
 

--- a/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/Context/REstateEntityFrameworkCoreContext.cs
+++ b/test/REstate.Engine.Repositories.EntityFrameworkCore.Tests/Features/Context/REstateEntityFrameworkCoreContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using REstate.Tests.Features.Context;
 
@@ -8,15 +9,21 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore.Tests.Features.Context
         : REstateContext<TState, TInput>
     {
         #region GIVEN
-        public Task Given_EntityFrameworkCore_is_the_registered_repository()
+        public async Task Given_EntityFrameworkCore_is_the_registered_repository()
         {
+            var options = new DbContextOptionsBuilder()
+                //.UseInMemoryDatabase("REstateScenarioTests")
+                .UseSqlServer(
+                    "Server=(localdb)\\mssqllocaldb;Database=REstateEfTestsIntegrated;Trusted_Connection=True;MultipleActiveResultSets=true")
+                .Options;
+
             CurrentHost.Agent().Configuration
                 .RegisterComponent(new EntityFrameworkCoreRepositoryComponent(
-                    new DbContextOptionsBuilder()
-                        .UseInMemoryDatabase("REstateScenarioTests")
-                        .Options));
+                    options));
 
-            return Task.CompletedTask;
+            await new REstateDbContextFactory(options).CreateContext().Database.EnsureCreatedAsync(CancellationToken.None);
+
+            //return Task.CompletedTask;
         }
         #endregion
 

--- a/test/REstate.Tests/Units/MachineTests.cs
+++ b/test/REstate.Tests/Units/MachineTests.cs
@@ -30,8 +30,7 @@ namespace REstate.Tests.Units
                 .CreateMachineAsync(schematic).GetAwaiter().GetResult();
 
             // Assert
-            Assert.StartsWith($"{schematic.SchematicName}/", machine.ToString(), StringComparison.Ordinal);
-            Assert.EndsWith(machine.MachineId, machine.ToString(), StringComparison.Ordinal);
+            Assert.Equal(machine.MachineId, machine.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
<!--
Requirements
* All new code requires tests to ensure against regressions
-->

<!-- Description of what the objective is and any changes needed -->
This PR focuses on Request-Response path applications as opposed to long-lived contexts as has previously been the focus. In the case of both new optimizations being adopted, users can see a reduction in __2/3rds__ of the read operations.

### `GetMachineReference(string machineId)`
In request life-cycles a machine must be retrieved before a signal or input/payload can be sent, which requires I/O to ensure the machine exists. This has been mitigated with a new method on IStateEngine that does not require any I/O and is synchronous: `GetMachineReference`. 

This also opens the door to more usage patterns where a machine reference would have been desired to store, but the I/O requirement meant designs had to instead hold a lower component and lazy initialize.

### `IOptimisticallyConcurrentStateRepository<TState, TInput>`
REstate is designed to minimize the possibility of stale writes for State as it's primary responsibility. The issue arises that each data-store handles concurrency differently, some with optimistic some pessimistic, and many have stale read semantics with eventual consistency. In the case of stale reads, this highly increases the chance of hitting a concurrency exception and needing to go through retry cycles. These differences has meant REstate has had to handle the worst case of each possible implementation previously. This is now being addressed with an optional interface IOptimisticallyConcurrentStateRepository<TState, TInput>that a Repository may implement. When implemented, REstate will send its recently loaded state to the repository so that the repository can avoid another read before making an update.

#### Current Implementations

- EntityFrameworkCore

#### Planned Implementations

- Redis (StackExchange v2 effort)

<!-- Uncomment the following sections as needed -->

<!-- Explain what other alternates were considered and why the proposed version was selected
### Alternate Designs
-->

### Why Should This Be In Core?
Required handling of new interface.

### Benefits
Best case scenario of no contention reduces database calls by at least 1 and 3 in EntityFramework's case.

### Possible Drawbacks
Elevated burden on caller to handle retries in hot paths.

### Related Issues

<!-- Enter any applicable issue numbers here -->
