### PR TITLE
Added NaturalStateName to EFCore models

### DIFF
--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/Machine.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/Machine.cs
@@ -20,5 +20,10 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
         public byte[] SchematicBytes { get; set; }
         
         public List<StateBagEntry> StateBagEntries { get; set; }
+
+        /// <summary>
+        /// If Machine uses NaturalStateMachine flows, this property reflects the value of <see cref="TypeState.GetStateName"/>
+        /// </summary>
+        public string NaturalStateName { get; set; }
     }
 }

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/REstateDbContext.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/REstateDbContext.cs
@@ -31,7 +31,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
 
             modelBuilder.Entity<Machine>()
                 .HasKey(status => status.MachineId);
-            
+
             modelBuilder.Entity<Machine>()
                 .Property(machine => machine.MachineId)
                 .IsUnicode(false)
@@ -42,7 +42,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
                 .Property(machine => machine.StateJson)
                 .IsUnicode(false)
                 .IsRequired();
-            
+
             modelBuilder.Entity<Machine>()
                 .Property(status => status.CommitNumber)
                 .IsRequired()
@@ -59,12 +59,21 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
                 .IsRequired();
 
             modelBuilder.Entity<Machine>()
+                .Property(p => p.NaturalStateName)
+                .IsUnicode(false)
+                .HasMaxLength(450)
+                .IsRequired(false);
+
+            modelBuilder.Entity<Machine>()
                 .HasMany(machine => machine.MetadataEntries)
                 .WithOne();
-            
+
             modelBuilder.Entity<Machine>()
                 .HasMany(machine => machine.StateBagEntries)
                 .WithOne();
+
+            modelBuilder.Entity<Machine>()
+                .HasIndex(machine => new { machine.SchematicName, machine.NaturalStateName, machine.UpdatedTime });
 
             modelBuilder.Entity<MetadataEntry>()
                 .HasKey(entry => new
@@ -72,7 +81,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
                     entry.MachineId,
                     entry.Key
                 });
-            
+
             modelBuilder.Entity<MetadataEntry>()
                 .Property(entry => entry.MachineId)
                 .IsUnicode(false)
@@ -94,13 +103,13 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
                     entry.MachineId,
                     entry.Key
                 });
-            
+
             modelBuilder.Entity<StateBagEntry>()
                 .Property(entry => entry.MachineId)
                 .IsUnicode(false)
                 .HasMaxLength(450)
                 .IsRequired();
-            
+
             modelBuilder.Entity<StateBagEntry>()
                 .Property(entry => entry.Key)
                 .IsUnicode(false)
@@ -119,7 +128,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
         public DbSet<Machine> Machines { get; set; }
 
         public DbSet<MetadataEntry> MetadataEntries { get; set; }
-        
+
         public DbSet<StateBagEntry> StateBagEntries { get; set; }
 
         public DbSet<Schematic> Schematics { get; set; }

--- a/src/REstate.Engine.Repositories.EntityFrameworkCore/Repository.cs
+++ b/src/REstate.Engine.Repositories.EntityFrameworkCore/Repository.cs
@@ -105,6 +105,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
             var schematicBytes = schematic.ToSchematicRepresentation();
 
             var stateJson = schematic.InitialState.ToStateRepresentation();
+            var naturalStateName = schematic.InitialState is TypeState typeState ? typeState.GetStateName() : null;
 
             const long commitNumber = 0L;
             var updatedTime = DateTimeOffset.UtcNow;
@@ -115,6 +116,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
                 SchematicName = schematic.SchematicName,
                 SchematicBytes = schematicBytes,
                 StateJson = stateJson,
+                NaturalStateName = naturalStateName,
                 CommitNumber = commitNumber,
                 UpdatedTime = updatedTime
             };
@@ -166,6 +168,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
             var schematicBytes = schematic.ToSchematicRepresentation();
 
             var stateJson = schematic.InitialState.ToStateRepresentation();
+            var naturalStateName = schematic.InitialState is TypeState typeState ? typeState.GetStateName() : null;
 
             const long commitNumber = 0L;
             var updatedTime = DateTimeOffset.UtcNow;
@@ -193,6 +196,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
                     MachineId = machineId,
                     SchematicBytes = schematicBytes,
                     StateJson = stateJson,
+                    NaturalStateName = naturalStateName,
                     CommitNumber = commitNumber,
                     UpdatedTime = updatedTime,
                     MetadataEntries = metadataEntries
@@ -335,6 +339,7 @@ namespace REstate.Engine.Repositories.EntityFrameworkCore
                     var stateJson = state.ToStateRepresentation();
 
                     machineRecord.StateJson = stateJson;
+                    machineRecord.NaturalStateName = state is TypeState typeState ? typeState.GetStateName() : null;
                     machineRecord.CommitNumber++;
                     machineRecord.UpdatedTime = DateTimeOffset.UtcNow;
 

--- a/src/REstate.EntityFrameworkCore.Migrations.SqlServer/DesignTimeREstateDbContextFactory.cs
+++ b/src/REstate.EntityFrameworkCore.Migrations.SqlServer/DesignTimeREstateDbContextFactory.cs
@@ -14,7 +14,9 @@ namespace REstate.EntityFrameworkCore.Migrations.SqlServer
             return new REstateDbContextFactory(new DbContextOptionsBuilder<REstateDbContext>()
                     .UseSqlServer(
                         "Server=(localdb)\\mssqllocaldb;Database=REstate;Trusted_Connection=True;MultipleActiveResultSets=true",
-                        b => b.MigrationsAssembly(GetType().Assembly.FullName))
+                        b => b
+                            .MigrationsAssembly(GetType().Assembly.FullName)
+                            .EnableRetryOnFailure())
                     .Options)
                 .CreateContext();
         }

--- a/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.Designer.cs
+++ b/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using REstate.Engine.Repositories.EntityFrameworkCore;
 
 namespace REstate.EntityFrameworkCore.Migrations.SqlServer.Migrations
 {
     [DbContext(typeof(REstateDbContext))]
-    partial class REstateDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190411152735_NaturalStateName")]
+    partial class NaturalStateName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.cs
+++ b/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace REstate.EntityFrameworkCore.Migrations.SqlServer.Migrations
+{
+    public partial class NaturalStateName : Migration
+    {
+        private const string SqlServer = "Microsoft.EntityFrameworkCore.SqlServer";
+
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "NaturalStateName",
+                table: "Machines",
+                unicode: false,
+                maxLength: 450,
+                nullable: true);
+
+            if (migrationBuilder.ActiveProvider == SqlServer)
+            {
+                migrationBuilder.Sql(@"CREATE NONCLUSTERED INDEX IX_Machines_SchematicName_NaturalStateName_UpdatedTime
+ON [dbo].[Machines] ([SchematicName], [UpdatedTime], [NaturalStateName])
+INCLUDE ([MachineId], [CommitNumber], [StateJson], [SchematicBytes])");
+            }
+            else
+            {
+                migrationBuilder.CreateIndex(
+                    name: "IX_Machines_SchematicName_NaturalStateName_UpdatedTime",
+                    table: "Machines",
+                    columns: new[] { "SchematicName", "NaturalStateName", "UpdatedTime" });
+            }
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Machines_SchematicName_NaturalStateName_UpdatedTime",
+                table: "Machines");
+
+            migrationBuilder.DropColumn(
+                name: "NaturalStateName",
+                table: "Machines");
+        }
+    }
+}

--- a/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.cs
+++ b/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.cs
@@ -17,6 +17,8 @@ namespace REstate.EntityFrameworkCore.Migrations.SqlServer.Migrations
 
             if (migrationBuilder.ActiveProvider == SqlServer)
             {
+                migrationBuilder.Sql(@"UPDATE [dbo].[Machines] SET [NaturalStateName] = CAST(LEFT(JSON_VALUE([StateJson],'$.AssemblyQualifiedName'), CHARINDEX(',', JSON_VALUE([StateJson],'$.AssemblyQualifiedName')) - 1) AS VARCHAR(450))");
+
                 migrationBuilder.Sql(@"CREATE NONCLUSTERED INDEX IX_Machines_SchematicName_NaturalStateName_UpdatedTime
 ON [dbo].[Machines] ([SchematicName], [UpdatedTime], [NaturalStateName])
 INCLUDE ([MachineId], [CommitNumber], [StateJson], [SchematicBytes])");


### PR DESCRIPTION
<!--
Requirements
* All new code requires tests to ensure against regressions
-->

<!-- Description of what the objective is and any changes needed -->
Adds NaturalStateName column to the Machines table in the EFCore (SQL Server) provider to enable optimizations for Natural State Machine based systems.

<!-- Uncomment the following sections as needed -->

### Alternate Designs
Generics in DbContext and inheritance or composition patterns were considered, but meant consumers can use the model, but migrations would need to be created and tracked on consumer-side. This makes day 1 adoption harder, it may be worth it in the long-run, but existing consumers would have to take on a very large breaking change.

### Why Should This Be In Core?
Must be first-party support unless we split EF from the repo to support simpler forks. (Perhaps future goal?)

### Benefits
A major benefit of using a DB such as SQL is adding querying capabilities to your data to run reports, tracing, supervision, and some small cross-StateMachine checks on rare occasions. Incrementally exposing pieces of natural state machines, while could be seen as leaky, enables far more performant enablement of these scenarios.

### Possible Drawbacks
- Extension (Natural State Machines) leak into lower-level
- Extra column width allocated for non-natural machine records

### Related Issues

<!-- Enter any applicable issue numbers here -->
