### PR TITLE
Update Index for performance

### DIFF
--- a/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.cs
+++ b/src/REstate.EntityFrameworkCore.Migrations.SqlServer/Migrations/20190411152735_NaturalStateName.cs
@@ -17,18 +17,17 @@ namespace REstate.EntityFrameworkCore.Migrations.SqlServer.Migrations
 
             if (migrationBuilder.ActiveProvider == SqlServer)
             {
-                migrationBuilder.Sql(@"UPDATE [dbo].[Machines] SET [NaturalStateName] = CAST(LEFT(JSON_VALUE([StateJson],'$.AssemblyQualifiedName'), CHARINDEX(',', JSON_VALUE([StateJson],'$.AssemblyQualifiedName')) - 1) AS VARCHAR(450))");
 
                 migrationBuilder.Sql(@"CREATE NONCLUSTERED INDEX IX_Machines_SchematicName_NaturalStateName_UpdatedTime
-ON [dbo].[Machines] ([SchematicName], [UpdatedTime], [NaturalStateName])
-INCLUDE ([MachineId], [CommitNumber], [StateJson], [SchematicBytes])");
+ON [dbo].[Machines] ([SchematicName] ASC, [UpdatedTime] ASC, [NaturalStateName] ASC)
+INCLUDE ([MachineId])");
             }
             else
             {
                 migrationBuilder.CreateIndex(
                     name: "IX_Machines_SchematicName_NaturalStateName_UpdatedTime",
                     table: "Machines",
-                    columns: new[] { "SchematicName", "NaturalStateName", "UpdatedTime" });
+                    columns: new[] { "SchematicName", "NaturalStateName", "UpdatedTime", "MachineId" });
             }
         }
 


### PR DESCRIPTION
Update migration in place. Remove unneeded items from index


<!-- Description of what the objective is and any changes needed -->
This change aims to undo the previous implementation of the index Machines. The previous implementation did not preform at scale.

### Benefits
Restate now allows for an index search in finding Machines that exist in a certain state much more quickly.

### Related Issues
In order to move from 9.2 to this new version, a consumer needs to null out the index. This was done in place by running the following script on the consuming SQL db.

DROP INDEX [IX_Machines_SchematicName_NaturalStateName_UpdatedTime] ON [dbo].[Machines]
GO

Update [dbo].[Machines] set [NaturalStateName]= null

CREATE NONCLUSTERED INDEX [IX_Machines_SchematicName_NaturalStateName_UpdatedTime] ON [dbo].[Machines]
(
	[SchematicName] ASC,
	[UpdatedTime] ASC,
	[NaturalStateName] ASC
)
INCLUDE ([MachineId]) 
GO
